### PR TITLE
[fix] BottomSheet의 런타임 duplicate class 경고와 크래시 문제를 해결한다

### DIFF
--- a/Docs/Troubleshotting.md
+++ b/Docs/Troubleshotting.md
@@ -623,3 +623,170 @@ Xcode가 실행 전에 다음 작업을 수행한다.
 - `Debug executable` OFF에서 빠르다고 해서 Release 성능 검증을 대체하지는 않는다.
 - 실제 배포 성능은 Release 또는 TestFlight 빌드 기준으로 확인한다.
 - `Debug executable` ON에서만 10초 안팎 대기하는 현상은 실기기 디버깅 비용일 수 있으며, 그 자체만으로 앱 startup regression으로 판단하지 않는다.
+
+## 릴리스 빌드 지도 탭 진입 시 BottomSheet duplicate class 크래시
+
+기준일: 2026-06-05
+
+### 증상
+
+릴리스 빌드에서 앱 실행 후 팝팡지도 탭에 진입하면 잠깐 멈춘 뒤 크래시가 난다.
+
+대표 로그:
+
+```text
+objc[...] Class _TtC11BottomSheet24BottomSheetConfiguration is implemented in both
+.../PopPangApp.app/Frameworks/ThirdParty.framework/ThirdParty
+and
+.../PopPangApp.app/Frameworks/Coordinator.framework/Coordinator
+This may cause spurious casting failures and mysterious crashes.
+One of the duplicates must be removed or renamed.
+
+=== AttributeGraph: cycle detected through attribute ... ===
+Error: distanvePerminWidth is 0
+Thread 1: EXC_BAD_ACCESS
+```
+
+판단:
+
+- `BottomSheetConfiguration is implemented in both ...`가 1차 원인이다.
+- `AttributeGraph cycle`, layout warning, `distanvePerminWidth is 0`은 같이 보일 수 있지만, 이 로그 조합에서는 링크 중복으로 인한 런타임 클래스 충돌을 먼저 해결한다.
+- 지도 탭에서 `BottomSheet`를 실제로 쓰기 시작하면서 중복 로딩 문제가 드러난다.
+
+### 원인
+
+현재 PopPang 구조:
+
+```text
+PopPangApp.app
+ -> ThirdParty.framework
+    -> BottomSheet
+
+PopPangApp.app
+ -> Coordinator.framework
+    -> MapFeature.staticFramework
+       -> import BottomSheet
+```
+
+`BottomSheet` SPM product가 기본 static product로 처리되면 다음 문제가 생긴다.
+
+- `ThirdParty.framework`가 `BottomSheet` 코드를 포함한다.
+- `MapFeature`는 `.staticFramework`라서 `Coordinator.framework`에 합쳐진다.
+- `MapFeature`가 쓰는 `BottomSheet` 코드도 `Coordinator.framework` 안으로 들어갈 수 있다.
+- 앱 실행 시 Objective-C/Swift 런타임이 같은 클래스인 `BottomSheetConfiguration`을 두 framework에서 발견한다.
+- 그 결과 duplicate class 경고와 casting failure, `EXC_BAD_ACCESS`가 발생할 수 있다.
+
+중요:
+
+- 여러 Swift 파일에서 `import BottomSheet`를 쓰는 것 자체가 문제는 아니다.
+- 문제는 같은 SDK 구현 코드가 여러 dynamic framework 바이너리 안에 각각 포함되는 것이다.
+
+### 해결
+
+`Tuist/Package.swift`의 `PackageSettings.productTypes`에서 `BottomSheet`를 dynamic framework로 고정한다.
+
+```swift
+let packageSettings = PackageSettings(
+    productTypes: [
+        "BottomSheet": .framework,
+        ...
+    ]
+)
+```
+
+의미:
+
+- `BottomSheet` 구현 코드를 `ThirdParty.framework`나 `Coordinator.framework` 안에 각각 복사하지 않는다.
+- 앱 번들의 `BottomSheet.framework` 한 곳에서 로드되게 만든다.
+- `BottomSheetConfiguration` 같은 런타임 클래스가 한 번만 등록되도록 한다.
+
+`Projects/Shared/ThirdParty/Project.swift`의 `.external(name: "BottomSheet")`는 유지한다.
+
+```swift
+.external(name: "BottomSheet")
+```
+
+각 feature source에서는 실제 SDK 모듈명을 그대로 import한다.
+
+```swift
+import BottomSheet
+```
+
+### 언제 static framework를 쓰는가
+
+아래 조건이면 `.staticFramework`가 기본 선택이다.
+
+| 조건 | 예 | 이유 |
+| --- | --- | --- |
+| 앱 내부 전용 feature | `HomeFeature`, `MapFeature`, `SearchFeature` | 앱 밖에서 독립 SDK처럼 배포하지 않는다. |
+| leaf 모듈 | `Feature -> Domain/Core/DSKit/ThirdParty` | 다른 여러 모듈이 feature 구현을 다시 공유하지 않는다. |
+| feature 수가 많다 | `Projects/Features/*Feature` | 런타임 dynamic framework 수, embed/sign 대상, dyld 로드 비용을 줄인다. |
+| 런타임 교체가 필요 없다 | 대부분의 PopPang feature | 바이너리 경계보다 실행 단순성이 중요하다. |
+
+PopPang 기본 feature 설정:
+
+```swift
+product: .staticFramework
+```
+
+주의:
+
+- static feature라도 source boundary와 import boundary는 유지된다.
+- static은 "모듈이 아니다"라는 뜻이 아니다.
+- static dependency가 여러 dynamic framework에 각각 들어가면 duplicate class 문제가 생길 수 있다.
+
+### 언제 dynamic framework를 쓰는가
+
+아래 조건이면 `.framework`가 맞다.
+
+| 조건 | 예 | 이유 |
+| --- | --- | --- |
+| 여러 레이어가 공유하는 경계 | `Domain`, `Core`, `DSKit` | 여러 target이 명시적으로 import하는 계약/API 경계다. |
+| 앱 조립 또는 인프라 경계 | `Coordinator`, `Data`, `ThirdParty` | App이 별도 framework로 조립하는 큰 경계다. |
+| feature public interface | `SearchFeatureInterface`, `PopupDetailFeatureInterface` | 재사용 entry API를 명시적으로 노출한다. |
+| static이면 duplicate class가 난 SPM product | `BottomSheet`, `KakaoSDKCommon` | 같은 SDK 코드가 여러 dynamic framework에 복사되는 것을 막는다. |
+| static 기본값에서 링크/모듈 해석이 깨지는 SPM product | `Moya`, `Alamofire`, `GoogleSignIn` 전이 product | `no such module`, undefined symbols를 막는다. |
+
+SPM product override 기준:
+
+- 기본값으로 먼저 빌드한다.
+- 문제가 재현된 product만 최소 범위로 `PackageSettings.productTypes`에 추가한다.
+- `Class ... is implemented in both ...`가 나오면 해당 SDK 코드가 여러 dynamic framework에 들어갔는지 확인한다.
+- Firebase 계열처럼 static 전제가 강한 SDK는 무리하게 dynamic으로 고정하지 않는다.
+
+### 검증
+
+프로젝트 재생성:
+
+```sh
+tuist install
+tuist generate
+```
+
+생성된 프로젝트에서 확인:
+
+```sh
+rg -n "BottomSheet.framework" Projects/Shared/ThirdParty/ThirdParty.xcodeproj Projects/Coordinator/Coordinator.xcodeproj Projects/Features/MapFeature/MapFeature.xcodeproj -g "*.pbxproj"
+```
+
+기대:
+
+- `BottomSheet` 프로젝트가 별도로 생성된다.
+- App build phase에 `BottomSheet.framework`가 embed 대상 또는 copy files 대상으로 잡힌다.
+- `Coordinator.framework` 안에 `BottomSheetConfiguration` 구현이 중복 포함되지 않아야 한다.
+
+릴리스 빌드 확인:
+
+```sh
+xcodebuild -workspace PopPang.xcworkspace \
+  -scheme PopPangApp \
+  -configuration Release \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+  build
+```
+
+실기기 또는 TestFlight에서 확인:
+
+- 앱 실행 후 팝팡지도 탭에 진입한다.
+- 로그에 `Class _TtC11BottomSheet24BottomSheetConfiguration is implemented in both`가 다시 나오면 아직 해결되지 않은 상태다.
+- duplicate class 로그가 사라졌는데도 지도 탭에서 크래시가 나면 그때는 `AttributeGraph`, `BottomSheet` layout, NMapsMap marker/cluster 갱신을 별도 이슈로 분리해 추적한다.

--- a/Docs/static-dynamic-linking.md
+++ b/Docs/static-dynamic-linking.md
@@ -445,7 +445,7 @@ static은 상위 바이너리에 합쳐진다.
 | 외부 SDK product 허브인가? | `ThirdParty` | `.framework` |
 | SPM product가 static 기본값으로 링크 오류를 내는가? | `Moya`, `Alamofire` | `PackageSettings`에서 `.framework` |
 | SPM product가 dynamic 강제 시 링크 오류를 내는가? | Firebase 계열 | override하지 않음 |
-| SPM product가 static이면 duplicate class가 나는가? | KakaoSDKCommon | `PackageSettings`에서 `.framework` |
+| SPM product가 static이면 duplicate class가 나는가? | KakaoSDKCommon, BottomSheet | `PackageSettings`에서 `.framework` |
 
 ## PopPang 현재 SPM product override
 
@@ -464,6 +464,7 @@ local target의 `product: .staticFramework` 또는 `product: .framework`와는 �
 | `KakaoSDKShare` | PopupDetail share 구현에서 사용 |
 | `KakaoSDKTemplate` | Kakao share template 전이 의존 |
 | `KakaoSDKCommon` | Kakao product 공통 코드 중복 포함 방지 |
+| `BottomSheet` | MapFeature static 산출물이 Coordinator.framework에 합쳐질 때 ThirdParty.framework와 BottomSheet 코드가 중복 포함되는 문제 방지 |
 | `GoogleSignIn` | Google 로그인 구현에서 사용 |
 | `AppAuth`, `AppAuthCore`, `GTMAppAuth`, `GTMSessionFetcherCore` | GoogleSignIn 전이 의존 링크 안정화 |
 | `AppCheckCore`, `FBLPromises` | GoogleSignIn/AppCheck 전이 의존 링크 안정화 |

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -79,6 +79,9 @@ import PackageDescription
     // - KakaoSDK 직접 사용 product: `.framework` 유지
     //   - 이유: Data는 KakaoSDKAuth/User를, PopupDetailFeature는 KakaoSDKShare/Template을 직접 import한다.
     //     기본 static product로 두면 KakaoSDKCommon 코드가 Data.framework와 Coordinator.framework에 각각 포함되어 런타임 duplicate class 경고가 난다.
+    // - BottomSheet: `.framework` 유지
+    //   - 이유: 기본 static product로 두면 MapFeature static framework를 포함하는 Coordinator.framework와
+    //     ThirdParty.framework 양쪽에 BottomSheet 코드가 들어가 런타임 duplicate class 경고와 크래시가 난다.
     // - Moya, Alamofire: `.framework` 유지
     //   - 이유: 기본값으로 둘 때 `Moya` 쪽에서 `Alamofire`를 못 찾는 모듈 해석 문제가 실제로 재현됐다.
     //   - `Compound`는 feature에서 직접 들고 가지 않고 `ThirdParty` 허브를 통해 제공한다.
@@ -88,6 +91,7 @@ import PackageDescription
             "AppAuth": .framework,
             "AppAuthCore": .framework,
             "AppCheckCore": .framework,
+            "BottomSheet": .framework,
             "FBLPromises": .framework,
             "GoogleSignIn": .framework,
             "GTMAppAuth": .framework,


### PR DESCRIPTION
## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성 및 수정
- [x] Docs: 문서 작성 및 수정


## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->

릴리스 빌드에서 팝팡지도 탭 진입 시 `BottomSheetConfiguration` duplicate class 경고 이후 크래시가 발생할 수 있는 문제를 수정했습니다.

### 문제 원인

현재 PopPang 모듈 구조는 다음처럼 구성되어 있습니다.

| 영역 | product type | 설명 |
| --- | --- | --- |
| `PopPangApp` | `.app` | 최종 앱 산출물 |
| `Projects/Features/*Feature` | `.staticFramework` | 앱 내부 전용 leaf feature |
| `Coordinator` | `.framework` | App이 조립하는 전역 흐름/네비게이션 경계 |
| `Domain` | `.framework` | Feature/Data/Coordinator가 공유하는 계약 경계 |
| `Data` | `.framework` | repository 구현과 외부 SDK 로그인 구현 경계 |
| `Core` | `.framework` | 네트워크, 저장소, coordinator base 등 기반 모듈 |
| `DSKit` | `.framework` | 공통 UI/API 경계 |
| `ThirdParty` | `.framework` | 외부 SDK SPM product 링크 허브 |
| `FeatureInterface` | `.framework` | 재사용 entry API가 필요한 feature의 public 경계 |

지도 탭은 `MapFeature`에서 `BottomSheet`를 직접 사용합니다.

여기서 헷갈리기 쉬운 점은 `ThirdParty.framework`가 dynamic framework라는 사실과, `BottomSheet` SPM product가 static으로 링크되는지는 서로 다른 문제라는 점입니다.

- `ThirdParty.framework`는 dynamic framework입니다.
- 하지만 그 안에 링크되는 `BottomSheet` product가 static이면 `BottomSheet` 구현 코드가 `ThirdParty.framework` 바이너리 안으로 복사될 수 있습니다.
- `MapFeature`는 `.staticFramework`입니다.
- `MapFeature.staticFramework`는 런타임에 별도 framework로 로드되지 않고, 이 feature를 사용하는 `Coordinator.framework` 안으로 합쳐집니다.
- 이때 `MapFeature`가 사용한 static `BottomSheet` 코드도 `Coordinator.framework` 안으로 함께 들어갈 수 있습니다.

```text
PopPangApp.app
 -> ThirdParty.framework(dynamic)
    -> BottomSheet 코드 포함 가능(static product라서 복사됨)

PopPangApp.app
 -> Coordinator.framework(dynamic)
    -> MapFeature.staticFramework 코드 포함
       -> import BottomSheet
       -> BottomSheet 코드 포함 가능(static product라서 복사됨)
```

기존에는 `BottomSheet` SPM product가 Tuist 기본값인 static product로 처리될 수 있었습니다.

이 경우 앱 실행 시 실제로 로드되는 dynamic framework 두 곳에 `BottomSheet` 코드가 중복 포함될 수 있습니다.

- `ThirdParty.framework`
- `MapFeature.staticFramework`를 포함한 `Coordinator.framework`

그래서 릴리스 빌드에서 지도 탭 진입 시 아래와 같은 런타임 duplicate class 경고와 크래시가 발생할 수 있었습니다.

```text
Class _TtC11BottomSheet24BottomSheetConfiguration is implemented in both
.../ThirdParty.framework/ThirdParty
and
.../Coordinator.framework/Coordinator
```

### 해결 내용

`Tuist/Package.swift`에서 `BottomSheet` SPM product를 dynamic framework로 고정했습니다.

```swift
"BottomSheet": .framework,
```

이제 `BottomSheet` 구현 코드는 `ThirdParty.framework`나 `Coordinator.framework` 안에 각각 복사되지 않고, 앱 번들의 `BottomSheet.framework` 한 곳에서 로드됩니다.

따라서 `BottomSheetConfiguration` 같은 런타임 클래스가 중복 등록되는 문제를 방지합니다.

### 문서화

아래 문서도 함께 보강했습니다.

- `Docs/Troubleshotting.md`
  - 릴리스 빌드 지도 탭 진입 시 `BottomSheet` duplicate class 크래시 원인/해결/검증 방법 추가
  - static framework와 dynamic framework 선택 기준 추가

- `Docs/static-dynamic-linking.md`
  - `BottomSheet`를 dynamic override가 필요한 SPM product 목록에 추가
  - `KakaoSDKCommon`과 같은 duplicate class 방지 케이스로 정리

### static / dynamic 선택 기준

PopPang 기준으로는 다음 원칙을 따릅니다.

| 선택 | 사용하는 경우 |
| --- | --- |
| `.staticFramework` | 앱 내부 전용 feature, leaf feature, 런타임 framework 수를 줄이고 싶은 모듈 |
| `.framework` | 여러 레이어가 공유하는 계약/기반 모듈, App 조립 경계, 외부 SDK 허브, feature interface |
| SPM product `.framework` override | static 기본값에서 duplicate class 또는 링크 문제가 실제로 재현된 외부 SDK |

정리하면:

- 앱 내부 feature는 기본적으로 `.staticFramework`
- `Coordinator`, `Domain`, `Data`, `Core`, `DSKit`, `ThirdParty`는 `.framework`
- 외부 SDK는 먼저 기본값으로 두고, 실제 duplicate class/link 문제가 생긴 product만 `.framework`로 고정

### ThirdParty SPM product를 static으로 두는 기준

`ThirdParty.framework`가 dynamic인지와, 그 안에서 링크하는 외부 SDK product가 static/dynamic인지는 별도 판단입니다.

PopPang에서는 외부 SDK product를 무조건 dynamic으로 바꾸지 않고, 기본적으로 Tuist/SPM 기본값을 먼저 사용합니다. 즉 실제 문제가 없으면 static product로 두는 것이 기본 방향입니다.

| static으로 두는 기준 | 이유 | 예 |
| --- | --- | --- |
| SDK가 static 배포를 전제로 한다 | dynamic으로 강제하면 SDK 내부 auto-link나 binary/resource 연결이 깨질 수 있습니다. | Firebase 계열 |
| dynamic override 시 링크 오류가 난다 | `swiftCompatibility`, `UIUtilities`, undefined symbols 같은 전이 의존성 문제가 생길 수 있습니다. | Firebase를 dynamic으로 강제한 경우 |
| 한 dynamic framework 안에만 포함된다 | 같은 SDK 코드가 여러 dynamic framework에 중복 복사되지 않으면 duplicate class 위험이 낮습니다. | App 조립 계층에서만 직접 쓰는 SDK |
| duplicate class 로그가 없다 | `Class ... is implemented in both ...`가 없다면 굳이 dynamic으로 바꿀 이유가 없습니다. | 문제 재현 전의 기본 product |
| 런타임 framework 수를 늘리고 싶지 않다 | dynamic framework가 늘면 embed/sign 대상과 dyld 로드 비용이 늘어납니다. | 작은 leaf성 외부 라이브러리 |

정리하면:

- 외부 SDK는 먼저 static 기본값으로 둡니다.
- static 상태에서 빌드와 실행이 정상이고 duplicate class 로그가 없으면 그대로 둡니다.
- static 때문에 같은 SDK 코드가 여러 dynamic framework에 복사되면 해당 product만 `.framework`로 고정합니다.
- dynamic으로 강제했을 때 auto-link가 깨지는 SDK는 static 기본값을 유지합니다.
- Firebase 계열은 dynamic 강제보다 static 기본값 유지가 더 안전합니다.

### ThirdParty SPM product를 dynamic으로 고정하는 기준

외부 SDK product는 기본적으로 static을 먼저 유지하되, 아래 문제가 실제로 재현되면 해당 product만 `.framework`로 고정합니다.

| dynamic으로 고정하는 기준 | 이유 | 예 |
| --- | --- | --- |
| static이면 duplicate class가 난다 | 같은 SDK 구현 코드가 여러 dynamic framework 안에 각각 복사되어 런타임 클래스가 중복 등록됩니다. | `BottomSheet`, `KakaoSDKCommon` |
| 여러 dynamic framework가 같은 SDK를 직접 import한다 | 각 framework 링크 단계에서 static SDK 코드가 각각 포함될 수 있습니다. | `Data.framework`와 `Coordinator.framework` 양쪽에서 쓰는 Kakao 계열 |
| static 기본값에서 전이 의존성 링크가 깨진다 | 상위 framework 링크 단계에서 하위 product 심볼을 못 찾아 undefined symbols가 납니다. | `GoogleSignIn` 전이 product |
| static 기본값에서 모듈 해석이 깨진다 | product A가 product B를 framework 모듈처럼 참조해야 하는데 static 기본값으로는 `no such module`이 날 수 있습니다. | `Moya`, `Alamofire` |
| SDK가 런타임에 하나의 독립 framework로 로드되는 것이 더 안전하다 | Objective-C/Swift runtime class, resource, bundle 접근이 여러 바이너리에 흩어지는 것을 막습니다. | `BottomSheet.framework` |

이번 PR에서 `BottomSheet`를 dynamic으로 고정한 이유:

```text
BottomSheet static product
 -> ThirdParty.framework 안에 BottomSheet 코드 포함
 -> Coordinator.framework 안에도 BottomSheet 코드 포함
 -> BottomSheetConfiguration duplicate class 발생 가능
```

수정 후:

```text
BottomSheet dynamic product
 -> ThirdParty.framework는 BottomSheet.framework 참조
 -> Coordinator.framework도 BottomSheet.framework 참조
 -> BottomSheetConfiguration은 BottomSheet.framework 한 곳에서만 로드
```

주의할 점:

- dynamic이 더 모듈러다운 선택은 아닙니다.
- dynamic framework가 늘면 앱 번들의 framework 수, embed/sign 대상, dyld 로드 비용이 늘어납니다.
- 따라서 모든 외부 SDK를 무조건 dynamic으로 바꾸지 않습니다.
- 실제 duplicate class, undefined symbols, `no such module` 같은 문제가 재현된 product만 최소 범위로 dynamic override합니다.


## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- close #18


## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?


## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

검증한 내용:

- `tuist install` 성공
- `tuist generate` 성공
- 생성된 프로젝트에서 `BottomSheet.framework`가 별도 project/framework로 잡히는 것 확인

추가 확인 필요:

- Release 또는 TestFlight 빌드에서 팝팡지도 탭 진입 시 `BottomSheetConfiguration is implemented in both` 로그가 사라졌는지 확인
- duplicate class 로그가 사라진 뒤에도 지도 탭 크래시가 남는다면 `AttributeGraph`, `BottomSheet` layout, `NMapsMap` marker/cluster 갱신 문제를 별도 이슈로 분리해 추적


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 릴리스 빌드에서 지도 탭 진입 시 발생하는 크래시 문제를 해결했습니다.

* **문서**
  * 지도 탭 크래시 현상의 증상, 원인, 해결 방법을 담은 문제 해결 가이드를 추가했습니다.
  * 정적/동적 링킹 의사결정 문서를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->