### PR TITLE
[refactor] Coordinator TCA 전환을 진행한다

### DIFF
--- a/.agents/skills/tca-refactor/SKILL.md
+++ b/.agents/skills/tca-refactor/SKILL.md
@@ -24,9 +24,10 @@ PopPang의 Compound 기반 feature를 현재 루트 `Projects/*` 구조 안에�
 1. 루트 `Projects/*`를 실제 구현 대상으로 사용한다.
 2. `V1/*`는 이전 상태 비교나 Compound 원형 확인이 필요할 때만 참고한다.
 3. `AGENTS.md`의 plan-first 규칙을 계속 따른다.
-4. feature 내부 상태는 reducer로 옮기되, 전역 navigation ownership은 기존 coordinator 구조를 우선 유지한다.
+4. Coordinator 패턴은 제거 대상이다. 새 navigation ownership은 TCA reducer state/action으로 둔다.
 5. `PopupUsecaseProtocol`, `AdminUsecaseProtocol`, `UserUsecaseProtocol` 같은 public contract는 issue 범위가 명확히 허용하지 않는 한 초반에 분리하지 않는다.
 6. 실제 migration으로 구조 이해가 바뀌면 reference 문서를 같은 작업 범위 안에서 갱신한다.
+7. navigation 작업 전에는 `Docs/tca-navigation-guidelines.md`를 읽고 tree-based / stack-based 기준을 따른다.
 
 ## Issue 시작 흐름
 
@@ -50,22 +51,24 @@ issue 생성/assign/branch checkout의 자세한 절차는 `references/issue-bra
 2. target feature의 기존 Compound state/action/reaction 흐름을 읽는다.
 3. 현재 저장소에서 이미 TCA로 옮겨진 예시를 먼저 비교한다.
 4. reducer state, action, effect, dependency bridge의 초안을 잡는다.
-5. coordinator callback을 유지할지, route를 올릴지, 화면 로컬 상태를 남길지 구분한다.
-6. 구현 중 범위가 `Domain`, `Data`, `App`, `Coordinator`의 public contract로 번지면 작업을 멈추고 다시 승인을 받는다.
-7. 구현 후에는 테스트/빌드/수동 검증 결과를 남긴다.
-8. migration 결과에 따라 reference 문서를 갱신한다.
+5. tree-based `Destination`으로 둘지, stack-based `Path`로 둘지, 화면 로컬 상태로 남길지 구분한다.
+6. 화면 전환용 escaping closure가 있으면 reducer delegate action으로 교체하는 방향을 우선 검토한다.
+7. 구현 중 범위가 `Domain`, `Data`, `App`, legacy `Coordinator`의 public contract로 번지면 작업을 멈추고 다시 승인을 받는다.
+8. 구현 후에는 테스트/빌드/수동 검증 결과를 남긴다.
+9. migration 결과에 따라 reference 문서를 갱신한다.
 
 ## TCA 패턴 기준
 
 1. feature-scoped client를 만들어 `DIContainer.shared.resolve(...)`를 `DependencyValues` bridge 뒤로 숨긴다.
 2. reducer에는 비즈니스 상태, effect 타이밍에 직접 영향을 주는 상태, 테스트가 필요한 상태를 둔다.
 3. scroll offset, proxy, 일회성 animation 같은 순수 UI 임시 상태는 무조건 reducer로 올리지 않는다.
-4. feature 간 이동은 coordinator callback 또는 route로 올리고, feature가 다른 feature를 직접 조립하지 않도록 유지한다.
-5. 같은 feature 내부의 child reducer 상태를 부모 feature state가 소유해야 하고, coordinator navigation ownership을 변경하지 않아도 되는 경우에만 부분 `scope` 도입을 검토한다.
-6. push, sheet, fullScreen 존재 여부 자체를 부모가 소유해야 하거나 coordinator callback 제거가 필요한 경우에는 feature issue에서 `scope`를 강제로 도입하지 않고 coordinator 관련 후속 issue에서 검토한다.
-7. feature 모듈을 수정할 때 view에 callback 방식 coordinator 연결이 남아 있다면, callback 묶음 상단에 `// TODO: 코디네이터 패턴은 추후 TCA navigation/state ownership으로 전환 예정` 주석을 추가한다.
-8. coordinator 관련 후속 issue에서는 위 TODO 주석이 달린 callback 경계를 TCA navigation/state ownership 전환 후보 지점으로 검토한다.
-9. Root/MainTab/FeatureCoordinator 구조는 issue가 명시적으로 요구하지 않는 한 먼저 TCA로 바꾸지 않는다.
+4. feature 간 이동은 child delegate action으로 parent reducer에 올리고, feature가 다른 feature를 직접 조립하지 않도록 유지한다.
+5. root/auth/sheet/fullScreen처럼 동시에 하나만 떠야 하는 화면은 tree-based `@Reducer enum Destination` + `@Presents var destination`으로 모델링한다.
+6. push/drill-down처럼 누적되는 화면은 stack-based `@Reducer enum Path` + `StackState<Path.State>`로 모델링한다.
+7. 여러 presentation optional을 State에 직접 나열하지 않는다. Destination enum으로 모은다.
+8. child feature가 parent `Path.State`를 알도록 만들지 않는다. `NavigationLink(state:)`는 모듈성을 깨뜨릴 수 있으므로 parent boundary 안에서만 신중히 사용한다.
+9. 화면 전환용 `@escaping` closure는 새로 추가하지 않는다. 기존 closure는 feature migration 때 delegate action으로 제거한다.
+10. Root/MainTab/FeatureCoordinator 구조는 제거 대상이다. 새 작업은 `AppFeature`, `AuthFlowFeature`, `MainTabFeature` 기준으로 설계한다.
 
 구체적인 구조 기준과 현재 전환 상태는 `references/current-architecture.md`, `references/feature-migration-inventory.md`를 따른다.
 

--- a/.agents/skills/tca-refactor/references/current-architecture.md
+++ b/.agents/skills/tca-refactor/references/current-architecture.md
@@ -8,7 +8,8 @@
 
 - 실제 구현 대상: 루트 `Projects/*`
 - 비교용 reference: `V1/*`
-- root workspace: `Workspace.swift`는 `Projects/App`, `Projects/Coordinator`, `Projects/Features`, `Projects/Domain`, `Projects/Data`, `Projects/Shared`만 포함한다.
+- root workspace: 현재 `Workspace.swift`는 `Projects/App`, `Projects/Coordinator`, `Projects/Features`, `Projects/Domain`, `Projects/Data`, `Projects/Shared`를 포함한다.
+- `Projects/Coordinator`는 legacy 모듈이며 제거 대상이다.
 
 즉 현재 작업은 기본적으로 `V1/*`가 아니라 루트 `Projects/*`에 반영한다.
 
@@ -17,7 +18,7 @@
 ```text
 Projects
 ├── App
-├── Coordinator
+├── Coordinator              # legacy, 제거 대상
 ├── Domain
 ├── Data
 ├── Features
@@ -48,7 +49,8 @@ Projects
 - SDK 초기화
 - repository/usecase live 조립
 - `DIContainer` 등록
-- root coordinator 생성
+- `AppFeature` root store 생성으로 전환 예정
+- root/auth/main TCA navigation 소유 예정
 
 핵심 파일:
 
@@ -56,13 +58,15 @@ Projects
 - `Projects/App/Sources/AppCore/AppBootstrap.swift`
 - `Projects/App/Sources/AppCore/AppDependencyRegistry.swift`
 
-### Coordinator
+### Coordinator Legacy
 
-- `RootCoordinator -> MainTabCoordinator -> FeatureCoordinator` 구조를 사용한다.
-- main flow는 `MainTabCoordinatorView`의 단일 `NavigationStack(path:)`를 기준으로 한다.
+- `RootCoordinator -> MainTabCoordinator -> FeatureCoordinator` 구조가 아직 남아 있다.
+- 이 구조는 제거 대상이다.
+- 새 navigation은 `Docs/tca-navigation-guidelines.md`의 TCA tree-based / stack-based 기준을 따른다.
+- active main flow는 App 모듈의 `MainTabFeature`가 `StackState`와 `@Presents` destination으로 소유하는 방향이다.
 - 탭 root view는 중첩 `NavigationStack`을 만들지 않는다.
-- feature는 callback/route intent를 coordinator로 올린다.
-- route에는 `Binding`, `View`, 무거운 closure를 넣지 않는다.
+- feature는 화면 전환용 escaping closure 대신 reducer delegate action으로 navigation intent를 올린다.
+- path/destination state에는 `Binding`, `View`, 무거운 closure를 넣지 않는다.
 
 핵심 파일:
 
@@ -76,7 +80,7 @@ Projects
 - 현재 기본 상태관리는 여전히 Compound 기반이다.
 - TCA migration은 feature 단위 vertical slice로 진행 중이다.
 - feature는 `Domain`, `Core`, `DSKit`, `ThirdParty`를 주로 의존한다.
-- feature 간 직접 import는 예외를 줄이고 coordinator 조립을 우선한다.
+- feature 간 직접 import는 예외를 줄이고 parent TCA reducer 조립을 우선한다.
 
 ### Domain
 
@@ -134,7 +138,7 @@ Projects
 2. feature 전용 `Client` struct 정의
 3. `DIContainer.shared.resolve(...)`를 `DependencyValues` bridge 뒤에 숨김
 4. view는 `StoreOf<Reducer>`를 `@State`로 보유
-5. navigation은 아직 coordinator callback 중심으로 유지
+5. navigation은 TCA `Destination` / `Path` 중심으로 전환 중
 
 예:
 
@@ -143,17 +147,20 @@ Projects
 
 ## Migration 시 우선 지킬 원칙
 
-1. coordinator 구조를 먼저 재작성하지 않는다.
+1. Coordinator 구조는 제거 대상이다. 새 navigation 작업에서는 확장하지 않는다.
 2. `PopupUsecaseProtocol` 같은 넓은 public contract를 초반에 분리하지 않는다.
 3. reducer에는 비즈니스 상태와 effect 타이밍에 필요한 상태만 둔다.
 4. 순수 UI 임시 상태는 view local state로 남겨도 된다.
-5. feature 이동은 callback/route 경계를 유지한다.
-6. `V1/*`는 원형 비교용일 뿐, 수정 대상으로 가정하지 않는다.
+5. feature 이동은 delegate action으로 parent reducer에 올린다.
+6. tree-based navigation은 `@Reducer enum Destination`과 단일 `@Presents var destination`으로 모델링한다.
+7. stack-based navigation은 `@Reducer enum Path`와 `StackState<Path.State>`로 모델링한다.
+8. `V1/*`는 원형 비교용일 뿐, 수정 대상으로 가정하지 않는다.
 
 ## 링크/모듈 정책
 
 - feature 모듈은 기본적으로 `.staticFramework`
-- `ThirdParty`, `Core`, `DSKit`, `Domain`, `Data`, `Coordinator`는 공유 경계로 유지
+- `ThirdParty`, `Core`, `DSKit`, `Domain`, `Data`는 현재 공유 경계로 유지
+- `Coordinator`는 legacy 경계이며 App 의존성에서 제거한다.
 - 외부 SDK 선언은 `Projects/Shared/ThirdParty/Project.swift` 기준으로 본다.
 
 TCA migration 중에도 이 정책은 그대로 유지하는 것을 기본값으로 삼는다.

--- a/.agents/skills/tca-refactor/references/feature-migration-inventory.md
+++ b/.agents/skills/tca-refactor/references/feature-migration-inventory.md
@@ -1,6 +1,6 @@
 # Feature Migration Inventory
 
-이 문서는 PopPang의 Compound -> TCA 전환 현황과 issue 기반 우선순위를 기록한다.
+이 문서는 PopPang의 Compound -> TCA 전환 현황, Coordinator 제거 방향, issue 기반 우선순위를 기록한다.
 
 migration이 진행되면 이 문서를 함께 업데이트한다.
 
@@ -10,6 +10,16 @@ migration이 진행되면 이 문서를 함께 업데이트한다.
 - 활성 코드 기준: 루트 `Projects/*`
 
 ## 현재 상태 요약
+
+### Navigation 전환 기준
+
+- Coordinator 패턴은 제거 대상이다.
+- 화면 전환용 escaping closure는 제거 대상이다.
+- root/auth/sheet/fullScreen은 tree-based navigation으로 모델링한다.
+- push/drill-down은 stack-based navigation으로 모델링한다.
+- tree-based navigation에서 여러 destination이 있으면 `@Reducer enum Destination`과 단일 `@Presents var destination`을 사용한다.
+- stack-based navigation은 `@Reducer enum Path`와 `StackState<Path.State>`를 사용한다.
+- 자세한 기준은 `Docs/tca-navigation-guidelines.md`를 따른다.
 
 ### TCA 예시가 이미 존재하는 feature
 
@@ -39,14 +49,18 @@ migration이 진행되면 이 문서를 함께 업데이트한다.
 
 ### 1차
 
+- `AppFeature` / root navigation
+- `MainTabFeature` navigation 정리
 - `HomeFeature`
 - `PopupDetailFeature`
 
 이유:
 
+- Coordinator 모듈 제거의 진입점이다.
+- `MainTabFeature`에 이미 `StackState` 기반 초안이 있다.
 - 이미 reducer 초안이 존재한다.
 - `PopupUsecaseProtocol` 기반 전환 패턴을 먼저 굳히기 좋다.
-- coordinator callback 구조를 유지한 채 vertical slice로 진행할 수 있다.
+- 화면 전환용 escaping closure 제거 패턴을 검증하기 좋다.
 
 ### 2차
 
@@ -138,7 +152,8 @@ migration이 진행되면 이 문서를 함께 업데이트한다.
 - popup list state
 - loading / error state
 - like state synchronization
-- coordinator callback 유지 여부
+- 화면 전환용 escaping closure 제거 여부
+- delegate action으로 parent navigation intent 전달
 
 ### User/Admin feature
 
@@ -151,18 +166,21 @@ migration이 진행되면 이 문서를 함께 업데이트한다.
 - user/admin usecase 분리
 - session 관련 state
 - 화면별 async state 전이
+- root/auth tree-based navigation 영향
 
 ### MapFeature
 
 - first/second bottom sheet ownership
 - user location / map center state ownership
 - filter state와 detail state 분리
-- coordinator로 올릴 state와 feature 내부 state 구분
+- parent reducer로 올릴 navigation intent와 feature 내부 state 구분
+- `NaverMapCoordinator` SDK bridge와 화면 전환 coordinator를 구분
 
 ## TCA 전환이 끝난 뒤 검토할 구조 변경
 
 - `PopupUsecaseProtocol` 세분화 필요 여부
-- coordinator를 TCA store 기반으로 올릴 필요 여부
+- `Shared.Models`, `Shared.Clients`, `Shared.Caches` 분리 필요 여부
+- `SharedFeature` 분리 필요 여부
 - 문서 기준선 갱신
 
-이 항목은 `#35` 또는 후속 spike issue에서만 다루는 것을 기본값으로 삼는다.
+이 항목은 navigation ownership과 escaping routing 제거가 안정화된 뒤 후속 spike issue에서 다룬다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,96 @@ Role Prompt Workflow를 적용할 때는 아래 형식으로 답한다.
 - auto-pr에서 PR 생성 요청은 현재 브랜치를 원격에 게시하는 작업을 포함한다.
 - `.env`, `*.xcconfig`, `GoogleService-Info.plist`, `.codex/logs/*.jsonl`, Xcode/Tuist 생성물, 빌드 산출물, 인증키/토큰/비밀번호는 커밋하지 않는다.
 
-## 3. AI Work Logging
+## 3. TCA Navigation Migration Direction
+
+PopPang은 Coordinator 패턴을 제거하고 TCA navigation을 기준 구조로 전환한다.
+
+현재 코드에 `Projects/Coordinator` 모듈, `RootCoordinator`, `MainTabCoordinator`, feature coordinator, 화면 전환용 escaping closure가 남아 있어도 새 작업에서는 이를 확장하지 않는다. 기존 coordinator는 제거 대상이며, 새 화면 전환은 TCA reducer state/action으로 모델링한다.
+
+자세한 기준은 `Docs/tca-navigation-guidelines.md`를 먼저 읽는다.
+
+### 기본 방향
+
+- 앱 루트 전환은 `AppFeature`가 소유한다.
+- 인증/온보딩/회원가입 흐름은 `AuthFlowFeature`가 소유한다.
+- 메인 탭과 탭 공통 push/fullScreen/sheet 흐름은 `MainTabFeature`가 소유한다.
+- feature는 다른 feature를 직접 조립하지 않고 delegate action으로 intent만 올린다.
+- parent feature가 `StackState` 또는 `@Presents` destination을 변경해 실제 화면 전환을 수행한다.
+- 화면 전환을 위해 `@escaping` closure를 새로 추가하지 않는다.
+- SwiftUI view 내부의 버튼/컴포넌트 이벤트 closure와 UIKit/SDK delegate bridge는 화면 전환용 escaping closure와 구분한다.
+
+### Tree-based Navigation
+
+sheet, fullScreenCover, popover, alert, confirmationDialog, root/auth 단계처럼 동시에 하나만 활성화되어야 하는 화면은 tree-based navigation을 사용한다.
+
+여러 destination이 가능한 경우 여러 optional을 State에 나열하지 않는다. 아래처럼 `@Reducer enum Destination`을 따로 두고 State에는 단일 `@Presents var destination`만 둔다.
+
+```swift
+@Reducer
+struct InventoryFeature {
+    @Reducer
+    enum Destination {
+        case addItem(AddFeature)
+        case detailItem(DetailFeature)
+        case editItem(EditFeature)
+    }
+
+    @ObservableState
+    struct State {
+        @Presents var destination: Destination.State?
+    }
+
+    enum Action {
+        case destination(PresentationAction<Destination.Action>)
+    }
+}
+```
+
+### Stack-based Navigation
+
+popup detail처럼 push가 누적되거나 관련 상세로 다시 진입할 수 있는 drill-down 흐름은 stack-based navigation을 사용한다.
+
+stack destination은 parent feature 안의 `@Reducer enum Path`로 정의하고, parent State가 `StackState<Path.State>`를 소유한다. child feature가 parent의 `Path.State`를 직접 알도록 만들지 않는다. child는 `.delegate(...)` action을 올리고 parent가 `path.append(...)`를 결정한다.
+
+### Reducer Case Ordering
+
+reducer의 `switch action`은 읽는 순서를 일정하게 유지한다.
+
+1. binding, lifecycle, task
+2. 일반 상태 변경 action
+3. async response action
+4. child feature action과 delegate action
+5. navigation action: `path`, `destination`, dismiss
+
+상태 변경과 화면 전환이 섞이면 먼저 상태 변경 case를 모으고, 그 다음 화면 전환 case를 둔다.
+
+### Target Module Shape
+
+장기 목표 구조는 아래 방향을 따른다. 실제 폴더 분리는 점진적으로 진행한다.
+
+```text
+PopPang
+├─ AppFeature
+│  ├─ AuthFlowFeature
+│  │  ├─ OnboardingFeature
+│  │  ├─ LoginFeature
+│  │  └─ SignupFeature
+│  └─ MainTabFeature
+│     ├─ HomeFeature
+│     ├─ CalendarFeature
+│     ├─ MapFeature
+│     ├─ FavoriteFeature
+│     └─ ProfileFeature
+├─ SharedFeature
+└─ Shared
+   ├─ Models
+   ├─ Clients
+   └─ Caches
+```
+
+현재 `Domain`의 entity/usecase/repository 계약은 즉시 `Shared`로 옮기지 않는다. 먼저 TCA navigation ownership과 escaping routing 제거를 안정화한 뒤, `Shared.Models`, `Shared.Clients`, `Shared.Caches` 분리를 별도 계획으로 진행한다.
+
+## 4. AI Work Logging
 
 Codex 작업은 재현성, 디버깅 가능성, 오류 원인 추적을 위해 최소 로그를 남긴다.
 

--- a/Docs/Troubleshotting.md
+++ b/Docs/Troubleshotting.md
@@ -22,9 +22,9 @@ static/dynamic product type 선택 기준은 `Docs/static-dynamic-linking.md`를
 해결:
 
 - 각 탭의 팝업 선택은 탭 내부 route로 직접 push하지 않는다.
-- `HomeFeatureView`, `CalendarFeatureView`, `MapFeatureView`, `FavoritesFeatureView`, `AlertFeatureView` 등은 `onSelectPopup` 콜백만 호출한다.
-- 각 탭 coordinator는 해당 콜백을 `MainTabCoordinator`로 전달한다.
-- `MainTabCoordinatorView`가 `NavigationStack`으로 `TabView`를 감싸고, `MainTabRoute.popupDetail`을 `navigationDestination(item:)` 상위 destination으로 push한다.
+- legacy coordinator 구조에서는 `HomeFeatureView`, `CalendarFeatureView`, `MapFeatureView`, `FavoritesFeatureView`, `AlertFeatureView` 등이 `onSelectPopup` 콜백을 호출하고, 각 탭 coordinator가 이를 `MainTabCoordinator`로 전달했다.
+- TCA 전환 구조에서는 각 feature가 `.delegate(.popupSelected(...))` action을 올리고, `MainTabFeature`가 `Path.popupDetail`을 `StackState`에 append한다.
+- `MainTabFeatureView`가 하나의 상위 `NavigationStack`으로 `TabView`를 감싸고, `MainTabFeature.Path.popupDetail`을 상위 destination으로 push한다.
 - 상위 destination으로 열린 `PopupDetailFeatureView`는 `hidesSystemTabBar: false`로 생성한다. 이 화면은 이미 `TabView` 바깥 destination이라 숨길 탭바가 없다.
 
 주의:

--- a/Docs/poppang-architecture.md
+++ b/Docs/poppang-architecture.md
@@ -22,7 +22,8 @@ PopPang은 팝업스토어 정보를 키워드, 검색, 필터, 달력, 지도, 
 - SwiftUI 기반 iOS 앱
 - Tuist 기반 workspace/project 구성
 - Micro Feature Architecture
-- Compound 기반 Feature 상태 관리
+- Compound 기반 Feature 상태 관리를 TCA로 점진 전환 중
+- 화면 전환은 Coordinator 패턴에서 TCA tree-based / stack-based navigation으로 전환 중
 - Moya 기반 네트워크와 async/await wrapper
 - Firebase, KakaoSDK, GoogleSignIn, Google Mobile Ads, NMapsMap, Kingfisher, BottomSheet 사용
 - iOS deployment target은 현재 `17.0` 기준
@@ -32,7 +33,7 @@ PopPang은 팝업스토어 정보를 키워드, 검색, 필터, 달력, 지도, 
 ```text
 Projects
 ├── App
-├── Coordinator
+├── Coordinator              # legacy, 제거 대상
 ├── Domain
 ├── Data
 ├── Features
@@ -58,6 +59,8 @@ Projects
 
 `V0/`는 기존 단일 타깃 구현과 참고 자료 성격이다. 모듈러 구현의 실제 변경은 기본적으로 `Projects/` 아래에서 판단한다.
 
+장기 목표 구조는 `Docs/tca-navigation-guidelines.md`의 `AppFeature`, `AuthFlowFeature`, `MainTabFeature`, `SharedFeature`, `Shared.Models`, `Shared.Clients`, `Shared.Caches` 방향을 따른다. 현재 `Domain`과 feature target을 즉시 대량 이동하지 않고, navigation ownership과 escaping routing 제거를 먼저 진행한다.
+
 ## 모듈 책임
 
 ### App
@@ -71,7 +74,8 @@ Projects
 - 앱 bootstrap
 - repository/usecase live 조립
 - `DIContainer` 등록
-- root coordinator 생성
+- `AppFeature` root store 생성
+- TCA root/auth/main navigation 소유
 - Info.plist, entitlements, app resources 관리
 
 주요 파일:
@@ -86,24 +90,32 @@ Projects
 
 위치: `Projects/Coordinator`
 
-역할:
+상태:
+
+- legacy 모듈
+- 제거 대상
+- 새 기능에서 확장하지 않음
+
+기존 역할:
 
 - Root flow, auth/onboarding/main 전환
 - MainTab 전역 navigation
 - Feature root 조립
-- Feature에서 올라온 intent를 상위 route로 전달
+- feature navigation callback adapter
 
 기준 문서:
 
 - `Projects/Coordinator/README.md`
 - `CoordinatorTree.png`
+- `Docs/tca-navigation-guidelines.md`
 
 핵심 원칙:
 
-- main flow는 `MainTabCoordinatorView`의 단일 `NavigationStack(path:)`를 기준으로 한다.
+- active main flow는 App 모듈의 `MainTabFeature`가 TCA `StackState`와 `@Presents` destination으로 소유한다.
+- root flow는 `RootCoordinator` bridge에서 `AppFeature` tree-based navigation으로 옮긴다.
+- feature coordinator와 화면 전환용 escaping closure는 제거한다.
 - 탭 root view는 중첩 `NavigationStack`을 만들지 않는다.
-- route는 navigation intent만 담고 `Binding`, `View`, 무거운 closure를 넣지 않는다.
-- feature coordinator는 root factory와 navigation adapter 역할을 우선한다.
+- path/destination state는 navigation intent와 child state만 담고 `Binding`, `View`, 무거운 closure를 넣지 않는다.
 - feature 내부 상태인 bottom sheet, selected item, sheet position은 feature state에 둔다.
 
 ### Features
@@ -113,9 +125,10 @@ Projects
 역할:
 
 - 사용자 화면과 화면별 state/action/effect 구현
-- Compound 기반 `*FeatureCompound`
+- 기존 Compound 기반 `*FeatureCompound`
+- 신규/전환 대상 TCA `@Reducer`
 - SwiftUI `*FeatureView`
-- 상위 flow로 전달할 intent callback 제공
+- reducer action과 delegate action을 통해 상위 flow에 navigation intent 전달
 
 기본 의존:
 
@@ -127,9 +140,10 @@ Projects
 주의:
 
 - feature가 다른 feature를 직접 import하는 구조는 기본 전략이 아니다.
-- feature 간 이동은 Coordinator route/factory를 통해 조립한다.
+- active main flow에서 feature 간 이동은 `MainTabFeature.Path` 또는 `MainTabFeature.Destination` state로 조립한다.
 - 화면 로컬 상태는 feature compound 또는 feature view local state에 둔다.
-- 전역 이동, 탭 바깥 push, full screen 전환은 상위 Coordinator로 올린다.
+- 전역 이동, 탭 바깥 push, full screen 전환은 상위 TCA parent reducer로 올린다.
+- 새 화면 전환용 `@escaping` closure를 추가하지 않는다.
 
 ### Domain
 
@@ -197,7 +211,7 @@ Feature
 - Network 공통 타입
 - Moya async wrapper
 - local storage
-- coordinator base
+- legacy coordinator base
 - logging/support/foundation extension
 
 주요 파일:
@@ -205,7 +219,7 @@ Feature
 - `Projects/Shared/Core/Sources/Network/BaseAPI.swift`
 - `Projects/Shared/Core/Sources/Network/NetworkProvider.swift`
 - `Projects/Shared/Core/Sources/Network/MoyaProvider+Async.swift`
-- `Projects/Shared/Core/Sources/Coordinator/Coordinator.swift`
+- `Projects/Shared/Core/Sources/Coordinator/**` legacy coordinator base
 
 ### Shared/DSKit
 
@@ -245,6 +259,13 @@ Feature
 
 ```text
 App
+ -> Features
+ -> Domain
+ -> Data
+ -> Shared
+
+Legacy only:
+App
  -> Coordinator
  -> Features
  -> Domain
@@ -273,6 +294,7 @@ Domain
 
 - `Domain -> Data`, `Domain -> Feature`, `Domain -> Coordinator` 방향 의존을 만들지 않는다.
 - feature 간 직접 의존은 기본 전략이 아니다.
+- `App -> Coordinator` 의존은 제거 대상이다. 새 의존성을 추가하지 않는다.
 - public protocol, DI, module dependency 변경은 작은 수정처럼 보이더라도 영향 범위를 넓게 본다.
 - Tuist 설정 변경은 빌드/link/runtime 위험을 함께 검토한다.
 
@@ -302,15 +324,20 @@ DI 변경 시 함께 확인할 파일:
 
 ## Navigation 기준
 
-자세한 기준은 `Projects/Coordinator/README.md`를 우선한다.
+자세한 기준은 `Docs/tca-navigation-guidelines.md`를 우선한다.
 
 계획 단계 체크:
 
 - 앱 루트 전환인지, MainTab 전역 이동인지, feature 로컬 상태인지 구분한다.
-- MainTab 전역 이동이면 `MainTabRoute` 또는 `MainTabFullScreenRoute` 영향 여부를 확인한다.
-- feature root에는 callback을 추가하고 feature coordinator가 상위 handler로 전달하는 구조를 우선한다.
-- route에는 runtime state, `Binding`, `View`, 무거운 closure를 넣지 않는다.
+- root/auth/sheet/fullScreen처럼 동시에 하나만 떠야 하는 화면은 tree-based navigation을 사용한다.
+- tree-based navigation에서 여러 destination이 있으면 `@Reducer enum Destination`을 만들고 State에는 `@Presents var destination: Destination.State?` 하나만 둔다.
+- push가 누적되는 drill-down 화면은 stack-based navigation을 사용한다.
+- MainTab 전역 push 이동이면 `MainTabFeature.Path` 영향 여부를 확인한다.
+- MainTab presentation 이동이면 `MainTabFeature.Destination` 영향 여부를 확인한다.
+- active main flow feature는 delegate action을 통해 `MainTabFeature`로 navigation intent를 전달한다.
+- path/destination state에는 runtime state, `Binding`, `View`, 무거운 closure를 넣지 않는다.
 - Map bottom sheet처럼 feature 내부 interaction 상태는 feature가 소유한다.
+- 화면 전환용 escaping closure는 제거 대상이며 새로 추가하지 않는다.
 
 ## 네트워크와 API 기준
 
@@ -338,7 +365,9 @@ DI 변경 시 함께 확인할 파일:
 원칙:
 
 - feature target은 기본적으로 `.staticFramework` 성격의 앱 내부 leaf feature로 본다.
-- `Coordinator`, `Domain`, `Data`, `Core`, `DSKit`, `ThirdParty`는 공유 경계로 본다.
+- `Coordinator`는 legacy 공유 경계이며 제거 대상이다.
+- `Domain`, `Data`, `Core`, `DSKit`, `ThirdParty`는 현재 공유 경계로 본다.
+- 장기적으로 `Shared.Models`, `Shared.Clients`, `Shared.Caches`, `SharedFeature` 분리를 검토한다.
 - 외부 SDK 링크 문제는 `ThirdParty`와 `Tuist/Package.swift` product type 정책을 같이 확인한다.
 - `tuist generate`, `make regen`, `make clean`, `make reinstall`은 파일을 생성/삭제/갱신할 수 있으므로 승인 없이 실행하지 않는다.
 - `Projects/**/Derived`, `*.xcodeproj`, `PopPang.xcworkspace`는 생성물 성격이므로 계획 없이 직접 수정하지 않는다.
@@ -358,6 +387,7 @@ DI 변경 시 함께 확인할 파일:
 
 문서 업데이트 후보:
 
+- `Docs/tca-navigation-guidelines.md`
 - `Docs/poppang-architecture.md`
 - `Projects/Coordinator/README.md`
 - `Docs/static-dynamic-linking.md`
@@ -376,7 +406,7 @@ DI 변경 시 함께 확인할 파일:
 요청별 기본 탐색 예:
 
 - 앱 시작, SDK, DI: `Projects/App/Sources/AppCore/**`
-- 루트 전환, 탭, 화면 이동: `Projects/Coordinator/**`, `Projects/Coordinator/README.md`
+- 루트 전환, 탭, 화면 이동: `Docs/tca-navigation-guidelines.md`, `Projects/App/Sources/AppCore/Navigation/**`, `Projects/Coordinator/**`
 - 화면 상태/UI: `Projects/Features/<FeatureName>/Sources/**`
 - 도메인 계약: `Projects/Domain/Sources/**`
 - API/DTO/repository: `Projects/Data/Sources/**`

--- a/Docs/static-dynamic-linking.md
+++ b/Docs/static-dynamic-linking.md
@@ -130,7 +130,7 @@ Data sources
 | --- | --- | --- |
 | `Projects/Features/*Feature` | `.staticFramework` | 앱 내부 전용 leaf feature. feature 수가 많으므로 런타임 dynamic framework 증가를 막는다. |
 | `SearchFeatureInterface`, `PopupDetailFeatureInterface` | `.framework` | 다른 모듈이 명시적으로 import하는 재사용 경계다. |
-| `Coordinator` | `.framework` | App이 조립하는 큰 흐름 경계이고 여러 feature static 산출물을 받아 최종 navigation shell을 만든다. |
+| `Coordinator` | `.framework` | legacy navigation shell이다. 제거 대상이며 새 기능에서 확장하지 않는다. |
 | `Domain` | `.framework` | Feature/Data/Coordinator가 공유하는 계약 경계다. |
 | `Data` | `.framework` | repository 구현과 외부 SDK 로그인 구현이 있는 인프라 경계다. |
 | `Core` | `.framework` | 네트워크, 저장소, formatter, coordinator base 등 여러 레이어가 공유하는 기반 모듈이다. |
@@ -146,7 +146,7 @@ PopPang feature는 아래 성격이다.
 - App 내부에서만 사용한다.
 - 외부 배포용 SDK가 아니다.
 - 런타임에 feature 바이너리를 교체하지 않는다.
-- feature 간 직접 import를 줄이고 Coordinator route/factory로 조립한다.
+- feature 간 직접 import를 줄이고 parent TCA reducer의 `Path`/`Destination`에서 조립한다.
 - feature 수가 많다.
 - 대부분 UI와 feature state를 가진 leaf 모듈이다.
 
@@ -165,7 +165,7 @@ static feature의 이점:
 - feature 모듈 경계는 유지하면서 런타임 framework 수는 줄인다.
 - 앱 시작 비용이 낮아질 가능성이 높다.
 - feature 자체를 embed/sign하지 않아도 된다.
-- App/Coordinator 입장에서는 feature 코드를 최종 산출물에 합쳐서 단순하게 실행할 수 있다.
+- App 입장에서는 feature 코드를 최종 산출물에 합쳐서 단순하게 실행할 수 있다.
 
 ## ThirdParty와 feature static의 관계
 
@@ -512,7 +512,7 @@ import Kingfisher
 PopPang 원칙:
 
 - feature는 다른 feature 구현을 직접 import하지 않는다.
-- 이동은 Coordinator route/factory/interface로 연결한다.
+- 이동은 parent TCA reducer의 `Path`/`Destination`과 feature delegate action으로 연결한다.
 - 재사용 public entry가 필요한 경우에만 `FeatureInterface`를 둔다.
 
 ### static이 빌드 속도에 항상 좋은가?

--- a/Docs/tca-navigation-guidelines.md
+++ b/Docs/tca-navigation-guidelines.md
@@ -1,0 +1,404 @@
+# TCA Navigation Guidelines
+
+이 문서는 PopPang의 Coordinator 제거와 TCA navigation 전환 기준이다.
+
+코드와 문서가 충돌하면 현재 코드를 먼저 확인하되, 새 navigation 작업은 이 문서의 방향을 따른다.
+
+## 결정 사항
+
+- Coordinator 패턴은 제거 대상이다.
+- `Projects/Coordinator` 모듈은 새 기능에서 확장하지 않는다.
+- 화면 전환용 `@escaping` closure는 제거 대상이다.
+- 새 화면 전환은 TCA state/action/reducer로 모델링한다.
+- tree-based navigation과 stack-based navigation을 함께 사용한다.
+- feature는 다른 feature를 직접 조립하지 않고 delegate action으로 intent만 올린다.
+
+## 용어
+
+### 화면 전환용 escaping closure
+
+상위 coordinator나 parent view에 화면 전환을 요청하기 위해 feature view initializer에 전달하던 closure를 말한다.
+
+예:
+
+```swift
+HomeFeatureView(
+    onSelectPopup: { userUuid, popup in
+        coordinator.push(.popupDetail(userUuid: userUuid, popup: popup))
+    }
+)
+```
+
+이 패턴은 제거 대상이다. TCA 전환 후에는 view가 store action을 보내고 reducer가 state를 변경한다.
+
+### UI 이벤트 closure
+
+작은 view component가 버튼 탭, toggle, text field commit 같은 UI 이벤트를 부모 view에 전달하기 위해 쓰는 closure다.
+
+예:
+
+```swift
+PopupCard(
+    onTap: { store.send(.popupTapped(popup)) },
+    onToggleLike: { store.send(.likeButtonTapped(popup)) }
+)
+```
+
+이 closure는 화면 전환용 closure가 아니다. 단, 이 closure 안에서 직접 navigation state를 변경하지 않고 store action을 보내는 것을 기본으로 한다.
+
+### SDK delegate bridge
+
+Naver map marker 선택, notification callback, UIKit delegate처럼 외부 SDK를 SwiftUI/TCA로 연결하기 위한 closure다. 이는 제거 대상과 구분한다. 가능한 경우 client dependency나 adapter로 감싸 reducer action으로 들어오게 만든다.
+
+## Tree-based Navigation
+
+tree-based navigation은 optional state와 enum state로 화면 표시 여부를 모델링한다.
+
+PopPang에서 tree-based navigation을 쓰는 경우:
+
+- 앱 root 전환: launch, auth, main
+- auth flow 단계: onboarding, login, signup
+- sheet
+- fullScreenCover
+- popover
+- alert
+- confirmationDialog
+- 동시에 하나만 활성화되어야 하는 destination
+
+### Destination 규칙
+
+여러 destination이 가능한 경우 State에 optional을 여러 개 두지 않는다.
+
+피해야 하는 형태:
+
+```swift
+@ObservableState
+struct State {
+    @Presents var search: SearchFeature.State?
+    @Presents var setting: SettingFeature.State?
+    @Presents var alert: AlertState<Action.Alert>?
+}
+```
+
+권장 형태:
+
+```swift
+@Reducer
+struct MainTabFeature {
+    @Reducer
+    enum Destination {
+        case search(SearchFeature)
+        case setting(SettingFeature)
+        case alert(AlertFeature)
+    }
+
+    @ObservableState
+    struct State {
+        @Presents var destination: Destination.State?
+    }
+
+    enum Action {
+        case destination(PresentationAction<Destination.Action>)
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .destination:
+                return .none
+            }
+        }
+        .ifLet(\.$destination, action: \.destination)
+    }
+}
+```
+
+이렇게 하면 하나의 parent에서 동시에 여러 presentation이 켜지는 invalid state를 줄일 수 있다.
+
+## Stack-based Navigation
+
+stack-based navigation은 push path를 collection state로 모델링한다.
+
+PopPang에서 stack-based navigation을 쓰는 경우:
+
+- popup detail push
+- related popup detail push
+- coming popup detail
+- review detail
+- alert에서 popup detail 진입
+- popup request management detail
+- profile setting처럼 탭 root 위로 push되는 화면
+
+### Path 규칙
+
+stack destination은 parent feature 안에 `@Reducer enum Path`로 둔다.
+
+```swift
+@Reducer
+struct MainTabFeature {
+    @Reducer
+    enum Path {
+        case popupDetail(PopupDetailFeature)
+        case reviewDetail(ReviewFeature)
+        case profileSetting(ProfileSettingFeature)
+    }
+
+    @ObservableState
+    struct State {
+        var path = StackState<Path.State>()
+    }
+
+    enum Action {
+        case path(StackActionOf<Path>)
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .path:
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path)
+    }
+}
+```
+
+child feature는 `MainTabFeature.Path.State`를 알지 않는다. child에서 `NavigationLink(state:)`를 직접 쓰면 parent의 Path 타입을 알아야 하므로 모듈성이 깨질 수 있다.
+
+권장 흐름:
+
+```swift
+case .home(.delegate(.popupSelected(let popup))):
+    state.path.append(
+        .popupDetail(
+            PopupDetailFeature.State(
+                userUuid: state.session.userUuid,
+                popup: popup,
+                isAdmin: state.session.isAdmin
+            )
+        )
+    )
+    return .none
+```
+
+## App-level Shape
+
+장기 목표는 아래 구조다. 실제 파일과 모듈 분리는 feature migration 속도에 맞춰 점진적으로 진행한다.
+
+```text
+PopPang
+│
+├─ AppFeature
+│  │
+│  ├─ AuthFlowFeature
+│  │  ├─ OnboardingFeature
+│  │  ├─ LoginFeature
+│  │  └─ SignupFeature
+│  │
+│  └─ MainTabFeature
+│     ├─ HomeFeature
+│     │  ├─ PopupListFeature
+│     │  ├─ PopupSearchFeature
+│     │  └─ PopupDetailFeature
+│     │
+│     ├─ CalendarFeature
+│     │  ├─ CalendarPopupListFeature
+│     │  └─ PopupDetailFeature
+│     │
+│     ├─ MapFeature
+│     │  ├─ NearbyPopupListFeature
+│     │  └─ PopupDetailFeature
+│     │
+│     ├─ FavoriteFeature
+│     │  ├─ FavoritePopupListFeature
+│     │  └─ PopupDetailFeature
+│     │
+│     └─ ProfileFeature
+│        ├─ NoticeFeature
+│        ├─ SettingFeature
+│        └─ AccountFeature
+│
+├─ SharedFeature
+│  ├─ PopupDetailFeature
+│  ├─ PopupCardFeature
+│  ├─ PopupImageFeature
+│  ├─ PopupLikeFeature
+│  ├─ PopupShareFeature
+│  ├─ EmptyStateFeature
+│  ├─ WebViewFeature
+│  └─ PermissionGuideFeature
+│
+└─ Shared
+   ├─ Models
+   ├─ Clients
+   └─ Caches
+```
+
+## Module Boundary
+
+### Feature
+
+Feature는 화면 상태와 액션을 가진다.
+
+- `State`: 화면 상태, child state, presentation state
+- `Action`: 사용자 입력, lifecycle, response, child action, delegate, navigation action
+- `Reducer`: 상태 변경, effect, child reducer composition
+- `View`: store action 전송과 store scoping
+
+### SharedFeature
+
+여러 화면에서 재사용되는 화면 또는 독립 UI feature다.
+
+예:
+
+- popup detail
+- popup card
+- popup image
+- popup like
+- popup share
+- empty state
+- web view
+- permission guide
+
+현재 `PopupDetailFeature`처럼 이미 독립 feature target으로 존재하는 모듈은 즉시 이동하지 않는다. 먼저 navigation ownership을 TCA로 옮긴 뒤, 중복과 의존성 방향이 분명해질 때 SharedFeature 분리를 진행한다.
+
+### Shared.Models
+
+공통 모델이다.
+
+예:
+
+- User
+- UserSession
+- Popup
+- PopupDetail
+- PopupImage
+- PopupCategory
+- AppError
+
+현재는 `Projects/Domain/Sources/Entities`가 이 역할을 상당 부분 담당한다. 즉시 파일 이동을 하지 않고, Domain 계약 안정화 후 별도 계획으로 분리한다.
+
+### Shared.Clients
+
+API, SDK, 위치, 딥링크 같은 작업 도구를 TCA dependency로 감싸는 계층이다.
+
+예:
+
+- AuthClient
+- UserClient
+- PopupClient
+- FavoriteClient
+- SearchClient
+- NotificationClient
+- LocationClient
+- DeepLinkClient
+
+현재는 `DIContainer.shared.resolve(...)`와 `@Dependency` bridge가 섞여 있다. 새 TCA feature는 feature-scoped client를 만들고, 내부에서 기존 usecase protocol을 감싼다.
+
+### Shared.Caches
+
+쿠키식 전역 저장소 dependency다.
+
+예:
+
+- UserSessionDependency
+- AuthTokenDependency
+- OnboardingDependency
+- FavoritePopupDependency
+- RecentSearchDependency
+- NotificationTokenDependency
+- AppSettingDependency
+
+UserDefaults, Keychain, in-memory cache, notification token sync는 reducer가 직접 접근하지 않고 dependency를 통해 접근한다.
+
+## Reducer Ordering
+
+`switch action` case 순서는 아래 순서를 따른다.
+
+1. binding
+2. lifecycle/task
+3. 일반 상태 변경 action
+4. async response action
+5. child action
+6. child delegate action
+7. stack navigation action
+8. tree destination action
+9. dismiss action
+
+예:
+
+```swift
+switch action {
+case .binding:
+    return .none
+
+case .task:
+    return .run { send in ... }
+
+case .tabSelected(let tab):
+    state.selectedTab = tab
+    return .none
+
+case .popupResponse(.success(let popups)):
+    state.popups = popups
+    return .none
+
+case .home(.delegate(.popupSelected(let popup))):
+    state.path.append(.popupDetail(.init(popup: popup)))
+    return .none
+
+case .path(.element(let id, let action)):
+    return reducePathAction(id: id, action: action, state: &state)
+
+case .destination(.presented(.search(.delegate(.dismiss)))):
+    state.destination = nil
+    return .none
+
+case .destination:
+    return .none
+}
+```
+
+## Migration Order
+
+### 1. App navigation 기준선
+
+- `AppFeature` 도입
+- `RootCoordinator` 제거
+- `MainTab`, `UserSession` 성격 타입을 Coordinator 밖으로 이동
+- App target에서 Coordinator dependency 제거
+
+### 2. MainTab navigation 정리
+
+- `MainTabFeature.Path`로 push destination 통합
+- `MainTabFeature.Destination`으로 sheet/fullScreen/search 통합
+- `@Presents`는 단일 destination enum state로 사용
+- tab root는 중첩 `NavigationStack`을 만들지 않음
+
+### 3. Feature escaping routing 제거
+
+- `HomeFeatureView(onSelectPopup:)` 같은 화면 전환 callback 제거
+- feature reducer에 delegate action 추가
+- parent reducer가 path/destination 변경
+- UI component closure는 store action forwarding 용도로만 유지
+
+### 4. Shared dependency 정리
+
+- feature-scoped client 표준화
+- 기존 usecase protocol bridge 정리
+- Shared.Models/Clients/Caches 분리 여부 검토
+
+## Do Not
+
+- 새 coordinator 타입을 만들지 않는다.
+- 새 화면 전환용 escaping closure를 추가하지 않는다.
+- route/path/destination state에 `Binding`, `View`, heavy closure를 넣지 않는다.
+- child feature가 parent `Path.State`를 직접 import하게 만들지 않는다.
+- API, DTO, Domain public protocol을 navigation migration과 함께 무리하게 바꾸지 않는다.
+- `NaverMapCoordinator` 같은 SDK bridge를 화면 전환 coordinator와 같은 범주로 취급하지 않는다.
+
+## References
+
+- Tree-based navigation: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/treebasednavigation
+- Stack-based navigation: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/stackbasednavigation

--- a/Projects/App/Sources/AppCore/Navigation/AppRootFlowView.swift
+++ b/Projects/App/Sources/AppCore/Navigation/AppRootFlowView.swift
@@ -1,0 +1,72 @@
+import Coordinator
+import DSKit
+import SwiftUI
+
+struct AppRootFlowView: View {
+    @State private var coordinator: RootCoordinator
+
+    @MainActor
+    init(coordinator: RootCoordinator) {
+        _coordinator = State(initialValue: coordinator)
+    }
+
+    var body: some View {
+        @Bindable var coordinator = coordinator
+
+        Group {
+            switch coordinator.destination {
+            case .launch:
+                LaunchScene(
+                    onContinue: {
+                        await coordinator.begin()
+                    }
+                )
+            case .onboarding:
+                OnboardingFlowView(coordinator: coordinator.onboardingCoordinator)
+            case .auth:
+                coordinator.authFlowCoordinator.makeRootView()
+            case .register:
+                coordinator.authFlowCoordinator.makeRegisterView()
+            case .main:
+                if let mainTabCoordinator = coordinator.mainTabCoordinator {
+                    MainTabFeatureHost(
+                        session: mainTabCoordinator.session,
+                        selectedTab: mainTabCoordinator.selectedTab,
+                        onLogout: {
+                            coordinator.logout()
+                        }
+                    )
+                    .id(mainTabCoordinator.session)
+                }
+            }
+        }
+    }
+}
+
+private struct LaunchScene: View {
+    let onContinue: @MainActor () async -> Void
+
+    var body: some View {
+        ZStack {
+            DSKitResource.image("Launch")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+        }
+        .task {
+            await onContinue()
+        }
+    }
+}
+
+private struct OnboardingFlowView: View {
+    let coordinator: OnboardingCoordinator
+
+    var body: some View {
+        CoordinatorContainer(coordinator: coordinator) {
+            coordinator.makeRootView()
+        } destination: { route in
+            coordinator.buildView(for: route)
+        }
+    }
+}

--- a/Projects/App/Sources/AppCore/Navigation/MainTabFeature.swift
+++ b/Projects/App/Sources/AppCore/Navigation/MainTabFeature.swift
@@ -1,0 +1,536 @@
+import ComposableArchitecture
+import Coordinator
+import Domain
+
+@Reducer
+struct MainTabFeature {
+    @ObservableState
+    struct State: Equatable {
+        var selectedTab: MainTab
+        var session: MainTabSession
+        var path = StackState<Path.State>()
+        @Presents var search: SearchDestinationFeature.State?
+        var logoutToken = 0
+
+        init(
+            selectedTab: MainTab = .home,
+            session: MainTabSession
+        ) {
+            self.selectedTab = selectedTab
+            self.session = session
+        }
+    }
+
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case path(StackActionOf<Path>)
+        case search(PresentationAction<SearchDestinationFeature.Action>)
+        case homePopupSelected(Popup)
+        case homeAlertTapped
+        case homeSearchTapped
+        case homeComingTapped([Popup])
+        case homeReportTapped
+        case homeManagePopupRequestsTapped
+        case calendarAlertTapped
+        case calendarPopupSelected(Popup)
+        case favoritesAlertTapped
+        case favoritesPopupSelected(Popup)
+        case favoritesBrowsePopupsTapped
+        case mapPopupSelected(Popup)
+        case profileAlertTapped
+        case profileSettingTapped(nickname: String, isAlerted: Bool)
+        case profileNotificationsTapped
+        case profileServiceTermsTapped
+    }
+
+    @Reducer
+    enum Path {
+        case popupDetail(PopupDetailDestinationFeature)
+        case comingPopupDetail(ComingPopupDetailDestinationFeature)
+        case reviewDetail(ReviewDetailDestinationFeature)
+        case alert(AlertDestinationFeature)
+        case popupRequest(PopupRequestDestinationFeature)
+        case popupRequestManagement(PopupRequestManagementDestinationFeature)
+        case popupRequestManagementDetail(PopupRequestManagementDetailDestinationFeature)
+        case profileSetting(ProfileSettingDestinationFeature)
+        case notifications(NotificationDestinationFeature)
+        case serviceTerms(ServiceTermsDestinationFeature)
+    }
+
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+
+            case .homePopupSelected(let popup),
+                    .calendarPopupSelected(let popup),
+                    .favoritesPopupSelected(let popup),
+                    .mapPopupSelected(let popup):
+                state.path.append(
+                    .popupDetail(
+                        .init(
+                            userUuid: state.session.userUuid,
+                            popup: popup,
+                            isAdmin: state.session.isAdmin
+                        )
+                    )
+                )
+                return .none
+
+            case .homeAlertTapped,
+                    .calendarAlertTapped,
+                    .favoritesAlertTapped,
+                    .profileAlertTapped:
+                state.path.append(.alert(.init(userUuid: state.session.userUuid)))
+                return .none
+
+            case .homeSearchTapped:
+                state.search = .init(
+                    userUuid: state.session.userUuid,
+                    nickname: state.session.nickname
+                )
+                return .none
+
+            case .homeComingTapped(let popups):
+                state.path.append(
+                    .comingPopupDetail(
+                        .init(
+                            userUuid: state.session.userUuid,
+                            popups: popups
+                        )
+                    )
+                )
+                return .none
+
+            case .homeReportTapped:
+                state.path.append(.popupRequest(.init(userUuid: state.session.userUuid)))
+                return .none
+
+            case .homeManagePopupRequestsTapped:
+                state.path.append(.popupRequestManagement(.init()))
+                return .none
+
+            case .favoritesBrowsePopupsTapped:
+                state.selectedTab = .home
+                return .none
+
+            case .profileSettingTapped(let nickname, let isAlerted):
+                state.path.append(
+                    .profileSetting(
+                        .init(
+                            userUuid: state.session.userUuid,
+                            nickname: nickname,
+                            isAlerted: isAlerted
+                        )
+                    )
+                )
+                return .none
+
+            case .profileNotificationsTapped:
+                state.path.append(.notifications(.init()))
+                return .none
+
+            case .profileServiceTermsTapped:
+                state.path.append(.serviceTerms(.init()))
+                return .none
+
+            case .path(.element(let id, let action)):
+                switch action {
+                case .popupDetail(.delegate(.pushPopupDetail(let userUuid, let popup))):
+                    state.path.append(
+                        .popupDetail(
+                            .init(
+                                userUuid: userUuid,
+                                popup: popup,
+                                isAdmin: state.session.isAdmin
+                            )
+                        )
+                    )
+                    return .none
+
+                case .popupDetail(.delegate(.showReviews(let reviews))):
+                    state.path.append(.reviewDetail(.init(reviews: reviews)))
+                    return .none
+
+                case .popupDetail(.delegate(.close)):
+                    state.path.pop(from: id)
+                    return .none
+
+                case .comingPopupDetail(.delegate(.pushPopupDetail(let userUuid, let popup))):
+                    state.path.append(
+                        .popupDetail(
+                            .init(
+                                userUuid: userUuid,
+                                popup: popup,
+                                isAdmin: state.session.isAdmin
+                            )
+                        )
+                    )
+                    return .none
+
+                case .alert(.delegate(.pushPopupDetail(let userUuid, let popup))):
+                    state.path.append(
+                        .popupDetail(
+                            .init(
+                                userUuid: userUuid,
+                                popup: popup,
+                                isAdmin: state.session.isAdmin
+                            )
+                        )
+                    )
+                    return .none
+
+                case .popupRequest(.delegate(.dismiss)),
+                        .popupRequestManagement(.delegate(.back)),
+                        .popupRequestManagementDetail(.delegate(.back)):
+                    state.path.pop(from: id)
+                    return .none
+
+                case .popupRequestManagement(.delegate(.showDetail(let submissionId))):
+                    state.path.append(
+                        .popupRequestManagementDetail(
+                            .init(submissionId: submissionId)
+                        )
+                    )
+                    return .none
+
+                case .profileSetting(.delegate(.logout)):
+                    state.logoutToken += 1
+                    return .none
+
+                case .profileSetting(.delegate(.nicknameUpdated(let nickname))):
+                    state.session.nickname = nickname
+                    return .none
+
+                default:
+                    return .none
+                }
+
+            case .path:
+                return .none
+
+            case .search(.presented(.delegate(.dismiss))):
+                state.search = nil
+                return .none
+
+            case .search(.presented(.delegate(.selectPopup(let popup)))):
+                let userUuid = state.session.userUuid
+                state.search = nil
+                state.path.append(
+                    .popupDetail(
+                        .init(
+                            userUuid: userUuid,
+                            popup: popup,
+                            isAdmin: state.session.isAdmin
+                        )
+                    )
+                )
+                return .none
+
+            case .search:
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path)
+        .ifLet(\.$search, action: \.search) {
+            SearchDestinationFeature()
+        }
+    }
+}
+
+@Reducer
+struct SearchDestinationFeature {
+    @ObservableState
+    struct State: Equatable, Identifiable {
+        let userUuid: String
+        let nickname: String
+
+        var id: String { "search-\(userUuid)" }
+    }
+
+    enum Action: Equatable {
+        case dismissTapped
+        case popupSelected(Popup)
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case dismiss
+            case selectPopup(Popup)
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .dismissTapped:
+                return .send(.delegate(.dismiss))
+            case .popupSelected(let popup):
+                return .send(.delegate(.selectPopup(popup)))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct PopupDetailDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        let userUuid: String
+        let popup: Popup
+        let isAdmin: Bool
+    }
+
+    enum Action: Equatable {
+        case relatedPopupSelected(String, Popup)
+        case deactivateCompleted
+        case reviewsTapped([Review])
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case pushPopupDetail(String, Popup)
+            case showReviews([Review])
+            case close
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .relatedPopupSelected(let userUuid, let popup):
+                return .send(.delegate(.pushPopupDetail(userUuid, popup)))
+            case .deactivateCompleted:
+                return .send(.delegate(.close))
+            case .reviewsTapped(let reviews):
+                return .send(.delegate(.showReviews(reviews)))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct ComingPopupDetailDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        let userUuid: String
+        let popups: [Popup]
+    }
+
+    enum Action: Equatable {
+        case popupSelected(String, Popup)
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case pushPopupDetail(String, Popup)
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .popupSelected(let userUuid, let popup):
+                return .send(.delegate(.pushPopupDetail(userUuid, popup)))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct AlertDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        let userUuid: String
+    }
+
+    enum Action: Equatable {
+        case popupSelected(String, Popup)
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case pushPopupDetail(String, Popup)
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .popupSelected(let userUuid, let popup):
+                return .send(.delegate(.pushPopupDetail(userUuid, popup)))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct ReviewDetailDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        let reviews: [Review]
+    }
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, _ in .none }
+    }
+}
+
+@Reducer
+struct PopupRequestDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        let userUuid: String
+    }
+
+    enum Action: Equatable {
+        case dismissTapped
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case dismiss
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .dismissTapped:
+                return .send(.delegate(.dismiss))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct PopupRequestManagementDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        init() {}
+    }
+
+    enum Action: Equatable {
+        case backTapped
+        case submissionSelected(String)
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case back
+            case showDetail(String)
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .backTapped:
+                return .send(.delegate(.back))
+            case .submissionSelected(let submissionId):
+                return .send(.delegate(.showDetail(submissionId)))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct PopupRequestManagementDetailDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        let submissionId: String
+    }
+
+    enum Action: Equatable {
+        case backTapped
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case back
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .backTapped:
+                return .send(.delegate(.back))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct ProfileSettingDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        let userUuid: String
+        let nickname: String
+        let isAlerted: Bool
+    }
+
+    enum Action: Equatable {
+        case logoutTapped
+        case nicknameUpdated(String)
+        case delegate(Delegate)
+
+        enum Delegate: Equatable {
+            case logout
+            case nicknameUpdated(String)
+        }
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .logoutTapped:
+                return .send(.delegate(.logout))
+            case .nicknameUpdated(let nickname):
+                return .send(.delegate(.nicknameUpdated(nickname)))
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+@Reducer
+struct NotificationDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        init() {}
+    }
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, _ in .none }
+    }
+}
+
+@Reducer
+struct ServiceTermsDestinationFeature {
+    @ObservableState
+    struct State: Equatable {
+        init() {}
+    }
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, _ in .none }
+    }
+}

--- a/Projects/App/Sources/AppCore/Navigation/MainTabFeatureView.swift
+++ b/Projects/App/Sources/AppCore/Navigation/MainTabFeatureView.swift
@@ -1,0 +1,327 @@
+import AlertFeature
+import CalendarFeature
+import ComposableArchitecture
+import Coordinator
+import FavoritesFeature
+import HomeFeature
+import MapFeature
+import PopupDetailFeature
+import PopupRequestFeature
+import PopupRequestManagementFeature
+import ProfileFeature
+import ReviewFeature
+import SearchFeature
+import SwiftUI
+
+struct MainTabFeatureHost: View {
+    @State private var store: StoreOf<MainTabFeature>
+    private let onLogout: @MainActor () -> Void
+
+    init(
+        session: MainTabSession,
+        selectedTab: MainTab = .home,
+        onLogout: @escaping @MainActor () -> Void
+    ) {
+        _store = State(
+            initialValue: Store(
+                initialState: MainTabFeature.State(
+                    selectedTab: selectedTab,
+                    session: session
+                )
+            ) {
+                MainTabFeature()
+            }
+        )
+        self.onLogout = onLogout
+    }
+
+    var body: some View {
+        MainTabFeatureView(store: store, onLogout: onLogout)
+    }
+}
+
+private struct MainTabFeatureView: View {
+    @Bindable var store: StoreOf<MainTabFeature>
+    let onLogout: @MainActor () -> Void
+
+    var body: some View {
+        NavigationStackStore(store.scope(state: \.path, action: \.path)) {
+            TabView(selection: $store.selectedTab) {
+                ForEach(MainTab.allCases, id: \.self) { tab in
+                    tabView(for: tab)
+                        .tabItem {
+                            tab.tabAsset(selected: store.selectedTab == tab).swiftUIImage
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 25, height: 25)
+                            Text(tab.title)
+                        }
+                        .tag(tab)
+                }
+            }
+        } destination: { store in
+            switch store.case {
+            case .popupDetail(let store):
+                PopupDetailDestinationView(store: store)
+            case .comingPopupDetail(let store):
+                ComingPopupDetailDestinationView(store: store)
+            case .reviewDetail(let store):
+                ReviewDetailDestinationView(store: store)
+            case .alert(let store):
+                AlertDestinationView(store: store)
+            case .popupRequest(let store):
+                PopupRequestDestinationView(store: store)
+            case .popupRequestManagement(let store):
+                PopupRequestManagementDestinationView(store: store)
+            case .popupRequestManagementDetail(let store):
+                PopupRequestManagementDetailDestinationView(store: store)
+            case .profileSetting(let store):
+                ProfileSettingDestinationView(store: store)
+            case .notifications(let store):
+                NotificationDestinationView(store: store)
+            case .serviceTerms(let store):
+                ServiceTermsDestinationView(store: store)
+            }
+        }
+        .fullScreenCover(item: $store.scope(\.search, action: \.search)) { store in
+            SearchDestinationView(store: store)
+        }
+        .onChange(of: store.logoutToken) { _, value in
+            guard value > 0 else { return }
+            onLogout()
+        }
+    }
+
+    @ViewBuilder
+    private func tabView(for tab: MainTab) -> some View {
+        switch tab {
+        case .home:
+            HomeFeatureView(
+                userUuid: store.session.userUuid,
+                nickname: store.session.nickname,
+                isAdmin: store.session.isAdmin,
+                onSelectPopup: { _, popup in
+                    store.send(.homePopupSelected(popup))
+                },
+                onShowAlert: { _ in
+                    store.send(.homeAlertTapped)
+                },
+                onSearch: { _ in
+                    store.send(.homeSearchTapped)
+                },
+                onShowComingPopups: { _, popups in
+                    store.send(.homeComingTapped(popups))
+                },
+                onReport: { _ in
+                    store.send(.homeReportTapped)
+                },
+                onManagePopupRequests: {
+                    store.send(.homeManagePopupRequestsTapped)
+                }
+            )
+            .id(store.session)
+        case .calendar:
+            CalendarFeatureView(
+                userUuid: store.session.userUuid,
+                onShowAlert: { _ in
+                    store.send(.calendarAlertTapped)
+                },
+                onSelectPopup: { _, popup in
+                    store.send(.calendarPopupSelected(popup))
+                }
+            )
+            .id(store.session)
+        case .map:
+            MapFeatureView(
+                userUuid: store.session.userUuid,
+                onSelectPopup: { _, popup in
+                    store.send(.mapPopupSelected(popup))
+                }
+            )
+            .id(store.session)
+        case .favorites:
+            FavoritesFeatureView(
+                userUuid: store.session.userUuid,
+                onShowAlert: { _ in
+                    store.send(.favoritesAlertTapped)
+                },
+                onSelectPopup: { _, popup in
+                    store.send(.favoritesPopupSelected(popup))
+                },
+                onBrowsePopups: {
+                    store.send(.favoritesBrowsePopupsTapped)
+                }
+            )
+            .id(store.session)
+        case .profile:
+            ProfileFeatureView(
+                userUuid: store.session.userUuid,
+                nickname: store.session.nickname,
+                isAlerted: store.session.isAlerted,
+                onShowAlert: { _ in
+                    store.send(.profileAlertTapped)
+                },
+                onProfileSetting: { _, nickname, isAlerted in
+                    store.send(.profileSettingTapped(nickname: nickname, isAlerted: isAlerted))
+                },
+                onNotification: {
+                    store.send(.profileNotificationsTapped)
+                },
+                onServiceTerms: {
+                    store.send(.profileServiceTermsTapped)
+                }
+            )
+            .id(store.session)
+        }
+    }
+}
+
+private struct SearchDestinationView: View {
+    let store: StoreOf<SearchDestinationFeature>
+
+    var body: some View {
+        SearchFeatureView(
+            userUuid: store.userUuid,
+            nickname: store.nickname,
+            onDismiss: {
+                store.send(.dismissTapped)
+            },
+            onSelectPopup: { popup in
+                store.send(.popupSelected(popup))
+            }
+        )
+        .accessibilityIdentifier("home_search")
+    }
+}
+
+private struct PopupDetailDestinationView: View {
+    let store: StoreOf<PopupDetailDestinationFeature>
+
+    var body: some View {
+        PopupDetailFeatureView(
+            userUuid: store.userUuid,
+            popup: store.popup,
+            isAdmin: store.isAdmin,
+            hidesSystemTabBar: false,
+            onSelectRelatedPopup: { userUuid, popup in
+                store.send(.relatedPopupSelected(userUuid, popup))
+            },
+            onDeactivateComplete: {
+                store.send(.deactivateCompleted)
+            },
+            onShowReviews: { reviews in
+                store.send(.reviewsTapped(reviews))
+            }
+        )
+    }
+}
+
+private struct ComingPopupDetailDestinationView: View {
+    let store: StoreOf<ComingPopupDetailDestinationFeature>
+
+    var body: some View {
+        ComingPopupDetailFeatureView(
+            userUuid: store.userUuid,
+            popups: store.popups,
+            onSelectPopup: { userUuid, popup in
+                store.send(.popupSelected(userUuid, popup))
+            }
+        )
+    }
+}
+
+private struct ReviewDetailDestinationView: View {
+    let store: StoreOf<ReviewDetailDestinationFeature>
+
+    var body: some View {
+        ReviewFeatureView(reviews: store.reviews)
+    }
+}
+
+private struct AlertDestinationView: View {
+    let store: StoreOf<AlertDestinationFeature>
+
+    var body: some View {
+        AlertFeatureView(
+            userUuid: store.userUuid,
+            onSelectPopup: { userUuid, popup in
+                store.send(.popupSelected(userUuid, popup))
+            }
+        )
+    }
+}
+
+private struct PopupRequestDestinationView: View {
+    let store: StoreOf<PopupRequestDestinationFeature>
+
+    var body: some View {
+        PopupRequestFeatureView(
+            userUuid: store.userUuid,
+            onDismiss: {
+                store.send(.dismissTapped)
+            }
+        )
+    }
+}
+
+private struct PopupRequestManagementDestinationView: View {
+    let store: StoreOf<PopupRequestManagementDestinationFeature>
+
+    var body: some View {
+        PopupRequestManagementFeatureView(
+            onBack: {
+                store.send(.backTapped)
+            },
+            onSelectSubmission: { submissionId in
+                store.send(.submissionSelected(submissionId))
+            }
+        )
+    }
+}
+
+private struct PopupRequestManagementDetailDestinationView: View {
+    let store: StoreOf<PopupRequestManagementDetailDestinationFeature>
+
+    var body: some View {
+        PopupRequestManagementDetailFeatureView(
+            submissionId: store.submissionId,
+            onBack: {
+                store.send(.backTapped)
+            }
+        )
+    }
+}
+
+private struct ProfileSettingDestinationView: View {
+    let store: StoreOf<ProfileSettingDestinationFeature>
+
+    var body: some View {
+        ProfileSettingFeatureView(
+            userUuid: store.userUuid,
+            nickname: store.nickname,
+            isAlerted: store.isAlerted,
+            onLogout: {
+                store.send(.logoutTapped)
+            },
+            onNicknameUpdated: { nickname in
+                store.send(.nicknameUpdated(nickname))
+            }
+        )
+    }
+}
+
+private struct NotificationDestinationView: View {
+    let store: StoreOf<NotificationDestinationFeature>
+
+    var body: some View {
+        NotificationFeatureView()
+    }
+}
+
+private struct ServiceTermsDestinationView: View {
+    let store: StoreOf<ServiceTermsDestinationFeature>
+
+    var body: some View {
+        ServiceTermsFeatureView()
+    }
+}

--- a/Projects/App/Sources/PopPangApp.swift
+++ b/Projects/App/Sources/PopPangApp.swift
@@ -16,7 +16,7 @@ struct PopPangApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootCoordinatorView(coordinator: bootstrap.makeRootCoordinator())
+            AppRootFlowView(coordinator: bootstrap.makeRootCoordinator())
                 .versionUpdateAlert()
                 .onOpenURL { url in
                     deepLinkHandler.handleIncomingURL(url)

--- a/Projects/Coordinator/README.md
+++ b/Projects/Coordinator/README.md
@@ -1,6 +1,14 @@
 # Coordinator Guide
 
-## 현재 기준
+## 상태
+
+`Projects/Coordinator`는 legacy 모듈이며 제거 대상이다.
+
+새 화면 전환은 이 모듈에 추가하지 않는다. PopPang의 navigation 기준은 `Docs/tca-navigation-guidelines.md`를 따른다.
+
+현재 남아 있는 coordinator 코드는 TCA navigation 전환 전까지 기존 동작을 이해하거나 제거 범위를 파악하기 위한 reference로만 본다.
+
+## 이전 기준
 
 이 모듈의 coordinator는 V0 컨셉을 따른다.
 
@@ -10,11 +18,13 @@
 - route 안에 `Binding`, `View`, 무거운 closure를 넣지 않는다.
 - container는 상태를 소유하지 않고 SwiftUI presentation 바인딩만 담당한다.
 
+이 기준은 더 이상 신규 구현 기준이 아니다. 신규 구현은 TCA reducer state/action으로 navigation을 소유한다.
+
 ## 흐름 소유권
 
 ### RootCoordinator
 
-앱 루트 상태를 소유한다.
+앱 루트 상태를 소유하던 legacy 계층이다.
 
 - launch
 - onboarding
@@ -23,9 +33,14 @@
 - main
 - logout 후 root 전환
 
+대체 목표:
+
+- `AppFeature`가 tree-based navigation으로 root destination을 소유한다.
+- launch/session/onboarding/auth/main 전환은 `AppFeature.State`와 `AppFeature.Destination`으로 표현한다.
+
 ### MainTabCoordinator
 
-메인 탭 안의 전역 navigation을 소유한다.
+메인 탭 안의 전역 navigation을 소유하던 legacy 계층이다. 현재 active main flow는 App 모듈의 `MainTabFeature` TCA shell로 옮기는 중이다.
 
 - `paths: [MainTabRoute]`
 - `fullScreen: MainTabFullScreenRoute?`
@@ -49,11 +64,17 @@
 
 MainTab 화면은 하나의 `NavigationStack(path:)`만 가진다. 각 탭 root를 다시 `CoordinatorContainer`로 감싸지 않는다.
 
+대체 목표:
+
+- push 흐름은 `MainTabFeature.Path`와 `StackState`로 표현한다.
+- sheet/fullScreen/search처럼 동시에 하나만 떠야 하는 흐름은 `MainTabFeature.Destination`과 `@Presents`로 표현한다.
+- `@Presents`는 State 안에 여러 개를 직접 나열하지 않고 `@Reducer enum Destination`의 단일 optional state로 사용한다.
+
 ### Feature Coordinator
 
-feature coordinator는 feature root를 조립하고, feature에서 올라온 intent를 상위 coordinator로 전달한다.
+feature coordinator는 feature root를 조립하고, feature에서 올라온 intent를 상위 coordinator로 전달하던 레거시 adapter다.
 
-현재 MainTab 아래에서 feature coordinator는 대부분 root factory와 navigation adapter 역할을 한다. 상위 handler가 없을 때만 독립 실행이나 demo를 위해 자기 local path로 fallback할 수 있다.
+현재 MainTab 아래에서 feature coordinator는 대부분 root factory와 navigation adapter 역할을 하며, 단계적으로 제거 대상이다. 상위 handler가 없을 때만 독립 실행이나 demo를 위해 자기 local path로 fallback할 수 있다.
 
 예:
 
@@ -64,11 +85,18 @@ feature coordinator는 feature root를 조립하고, feature에서 올라온 int
 - `ProfileCoordinator.onNotification`
 - `ProfileCoordinator.onServiceTerms`
 
+대체 목표:
+
+- feature view initializer에 화면 전환용 `@escaping` closure를 새로 추가하지 않는다.
+- feature reducer는 `.delegate(...)` action으로 navigation intent를 parent에 올린다.
+- parent reducer가 `path.append(...)` 또는 `destination = ...`로 실제 화면 전환을 결정한다.
+
 ## NavigationStack 규칙
 
-- main flow에서는 `MainTabCoordinatorView`가 단일 `NavigationStack(path: $coordinator.paths)`를 가진다.
+- active main flow에서는 App 모듈의 `MainTabFeatureView`가 TCA `StackState`와 `@Presents` destination을 사용해 navigation을 소유한다.
+- legacy main flow에서는 `MainTabCoordinatorView`가 단일 `NavigationStack(path: $coordinator.paths)`를 가진다.
 - 탭 root view는 중첩 `NavigationStack`을 만들지 않는다.
-- onboarding처럼 main flow와 분리된 독립 흐름은 `CoordinatorContainer`를 쓸 수 있다.
+- onboarding처럼 main flow와 분리된 독립 흐름도 최종적으로 `AuthFlowFeature` tree-based navigation으로 전환한다.
 - fullScreen 안에서 닫히는 독립 화면은 자체 stack을 가질 수 있다.
 
 ## Bottom Sheet 규칙
@@ -83,7 +111,7 @@ feature coordinator는 feature root를 조립하고, feature에서 올라온 int
 
 따라서 `MapCoordinator`에는 임시 `safeAreaInset` bottom sheet host를 두지 않는다.
 
-전역 bottom sheet가 필요할 때만 coordinator bottomSheet route를 사용한다.
+전역 bottom sheet가 필요하면 TCA `Destination` state로 모델링한다.
 
 ## Route 규칙
 
@@ -114,11 +142,12 @@ case regionSheet(
 ## 새 흐름 추가 체크리스트
 
 1. 앱 루트 전환인지, MainTab 전역 이동인지, feature 로컬 상태인지 먼저 정한다.
-2. MainTab 전역 이동이면 `MainTabRoute` 또는 `MainTabFullScreenRoute`에 case를 추가한다.
-3. feature root에는 callback을 추가하고, feature coordinator가 상위 handler로 전달한다.
-4. `MainTabCoordinator`에서 handler를 연결한다.
-5. `MainTabCoordinatorView`에서 route를 실제 view로 변환한다.
+2. root/auth/sheet/fullScreen이면 tree-based `Destination` 영향을 먼저 본다.
+3. push/drill-down이면 stack-based `Path` 영향을 먼저 본다.
+4. feature에는 화면 전환 callback을 추가하지 않고 delegate action을 추가한다.
+5. active 경로에서는 TCA view의 destination builder가 path/destination state를 실제 view로 변환한다.
 6. feature 안에서만 닫히는 UI state는 feature state에 둔다.
+7. legacy coordinator를 수정해야만 하는 경우에는 제거 계획과 함께 최소 범위로만 수정한다.
 
 ## 현재 구조 요약
 
@@ -132,4 +161,13 @@ RootCoordinator
     -> ProfileCoordinator
 ```
 
-`MainTabCoordinator`가 메인 flow의 V0 MainCoordinator 역할을 맡는다. feature coordinator는 root 조립과 intent 전달을 맡는다.
+`MainTabCoordinator`는 메인 flow의 V0 MainCoordinator 역할을 맡았던 legacy 구조다. 현재는 App의 `MainTabFeature`로 대체하는 중이며, feature coordinator는 제거 대상으로 본다.
+
+## 제거 순서
+
+1. `AppFeature`로 root flow를 대체한다.
+2. `MainTab`, `MainTabSession` 같은 App navigation 타입을 Coordinator 밖으로 옮긴다.
+3. App target의 `Coordinator` 의존성을 제거한다.
+4. `MainTabCoordinator`와 feature coordinator 활성 경로를 제거한다.
+5. feature별 화면 전환용 escaping closure를 reducer delegate action으로 교체한다.
+6. `Projects/Coordinator` 모듈과 workspace/project 의존성을 제거한다.

--- a/Projects/Coordinator/Sources/MainTabCoordinator/MainTab.swift
+++ b/Projects/Coordinator/Sources/MainTabCoordinator/MainTab.swift
@@ -7,7 +7,7 @@ public enum MainTab: Hashable, CaseIterable, Sendable {
     case favorites
     case profile
 
-    var title: String {
+    public var title: String {
         switch self {
         case .home:
             "홈"
@@ -71,7 +71,7 @@ public enum MainTab: Hashable, CaseIterable, Sendable {
         }
     }
 
-    func tabAsset(selected: Bool) -> CoordinatorImages {
+    public func tabAsset(selected: Bool) -> CoordinatorImages {
         selected ? selectedImage : image
     }
 }


### PR DESCRIPTION
## 💡 PR 유형
- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [x] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [x] Docs: 문서 작성 및 수정

## ✏️ 변경 사항
- `AppRootFlowView`, `MainTabFeature`, `MainTabFeatureView`를 추가해 App 모듈에서 메인 탭 navigation을 TCA `StackState`와 `@Presents` 기반으로 소유하는 진입점을 마련했습니다.
- `PopPangApp`의 root view를 기존 `RootCoordinatorView`에서 `AppRootFlowView`로 연결했습니다.
- `MainTab`의 tab title과 asset accessor를 App navigation shell에서 사용할 수 있도록 공개했습니다.
- `Docs/tca-navigation-guidelines.md`를 추가해 Coordinator 제거, tree-based navigation, stack-based navigation, reducer case ordering, 장기 모듈 구조 기준을 문서화했습니다.
- `AGENTS.md`에 새 에이전트가 따라야 할 TCA navigation migration 방향을 추가했습니다.
- `Docs/poppang-architecture.md`, `Projects/Coordinator/README.md`, `Docs/static-dynamic-linking.md`, `Docs/Troubleshotting.md`의 legacy Coordinator 설명을 TCA parent reducer 기준으로 갱신했습니다.
- `tca-refactor` 스킬과 reference 문서를 Coordinator 유지 전제에서 TCA navigation 전환 전제로 업데이트했습니다.

## 🚨 관련 이슈
- close #46

## 🎨 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [ ] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

### 구조 변경
- 이번 PR은 Coordinator를 즉시 삭제하기보다, App 모듈에 TCA navigation shell과 문서 기준선을 먼저 세우는 단계입니다.
- `MainTabFeature`는 push 흐름을 `Path` + `StackState`로, search fullScreen 흐름을 presentation state로 관리합니다.
- 문서 기준은 `@Reducer enum Destination` + 단일 `@Presents var destination`을 표준으로 정리했습니다. 현재 코드의 `search` presentation은 후속 작업에서 이 기준에 맞춰 `Destination` enum으로 이동할 예정입니다.

### 문서화
- `Docs/tca-navigation-guidelines.md`에 화면 전환용 escaping closure와 UI 이벤트 closure, SDK delegate bridge의 차이를 명시했습니다.
- `AGENTS.md`와 `tca-refactor` 스킬에 새 navigation 작업 전 반드시 확인해야 하는 기준 문서를 연결했습니다.
- 기존 Coordinator 문서는 legacy reference로 재정의하고, 신규 화면 전환을 추가하지 않도록 안내했습니다.

### 검증한 내용
- `git diff --cached --check`
- `git diff --stat origin/main...HEAD`
- `git diff --name-status origin/main...HEAD`
- `refactor/#46` 브랜치를 원격에 push했습니다.
- 이슈 `#46` 제목과 브랜치 기준으로 PR 제목/연결을 맞췄습니다.

### 추가 확인 필요
- 앱 빌드와 런타임 동작 검증은 아직 실행하지 않았습니다.
- `MainTabFeature`의 presentation state는 문서 기준에 맞춰 후속 작업에서 `Destination` enum으로 재정리해야 합니다.
- `Projects.pre_v2_restore_20260624_144115/` 백업 디렉터리는 PR에 포함하지 않았고, 로컬에만 유지했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 앱의 전체 화면 전환 구조가 개선되어, 시작/로그인/메인 흐름이 더 일관되게 동작합니다.
  * 메인 탭에서 검색, 상세 보기, 알림, 프로필 등으로 이동하는 흐름이 더 자연스러워졌습니다.

* **Bug Fixes**
  * 뒤로가기 후 탭바가 늦게 복귀하던 문제가 개선되었습니다.
  * 일부 화면 전환이 꼬이거나 중복되는 현상이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->