### PR TITLE
[refactor] MainTab TCA navigation 책임을 재구성한다 (후속)

### DIFF
--- a/Docs/poppang-architecture.md
+++ b/Docs/poppang-architecture.md
@@ -348,7 +348,7 @@ Domain
 
 ## DI 기준
 
-현재 DI는 `Domain`의 `DIContainer`와 `@Dependency`를 사용한다.
+현재 DI는 legacy와 TCA를 분리해서 본다.
 
 흐름:
 
@@ -357,8 +357,16 @@ AppDependencyRegistry.live()
  -> RepositoryImpl 생성
  -> UsecaseImpl 생성
  -> DIContainer.shared.register(..., for: Protocol.self)
- -> FeatureCompound에서 @Dependency로 resolve
+ -> legacy FeatureCompound에서 @Dependency로 resolve
+ -> AppBootstrap이 TCA feature-scoped client를 조립
+ -> Store.withDependencies(...)로 TCA reducer에 주입
 ```
+
+원칙:
+
+- legacy Compound는 `DIContainer`와 `@Dependency`를 유지할 수 있다.
+- TCA reducer는 `DependencyValues`만 사용한다.
+- TCA client `liveValue` 안에서 `DIContainer.shared.resolve(...)`를 직접 호출하지 않는다.
 
 DI 변경 시 함께 확인할 파일:
 

--- a/Docs/tca-navigation-guidelines.md
+++ b/Docs/tca-navigation-guidelines.md
@@ -383,7 +383,7 @@ API, SDK, 위치, 딥링크 같은 작업 도구를 TCA dependency로 감싸는 
 - LocationClient
 - DeepLinkClient
 
-현재는 `DIContainer.shared.resolve(...)`와 `@Dependency` bridge가 섞여 있다. 새 TCA feature는 feature-scoped client를 만들고, 내부에서 기존 usecase protocol을 감싼다.
+현재는 `DIContainer.shared.resolve(...)`와 `@Dependency` bridge가 섞여 있다. 새 TCA feature는 feature-scoped client를 만들고, 내부에서 기존 usecase protocol을 감싼다. 이때 TCA client의 `liveValue` 안에서 `DIContainer.shared.resolve(...)`를 직접 호출하지 않고, `AppBootstrap` 같은 composition root에서 concrete client를 조립해 `withDependencies`로 주입한다.
 
 ### Shared.Caches
 

--- a/Projects/App/Sources/AppCore/AppBootstrap.swift
+++ b/Projects/App/Sources/AppCore/AppBootstrap.swift
@@ -1,10 +1,14 @@
 import ComposableArchitecture
 import Core
 import Foundation
+import HomeFeature
+import PopupDetailFeature
 
 struct AppBootstrap {
     let sessionStorage: LocalSessionStorage
     let sessionClient: SessionClient
+    let homePopupClient: HomePopupClient
+    let popupDetailClient: PopupDetailClient
     let launchStateResolver: AppLaunchStateResolver
     let dependencies: AppDependencyRegistry
 
@@ -17,6 +21,13 @@ struct AppBootstrap {
             sessionStorage: sessionStorage,
             userUsecase: dependencies.usecases.userUsecase
         )
+        let homePopupClient = HomePopupClient.live(
+            popupUsecase: dependencies.usecases.popupUsecase
+        )
+        let popupDetailClient = PopupDetailClient.live(
+            popupUsecase: dependencies.usecases.popupUsecase,
+            adminUsecase: dependencies.usecases.adminUsecase
+        )
         let pushTokenStorage = PushTokenStorage(store: store)
         AppNotificationManager.shared.configure(
             sessionStorage: sessionStorage,
@@ -27,6 +38,8 @@ struct AppBootstrap {
         return AppBootstrap(
             sessionStorage: sessionStorage,
             sessionClient: sessionClient,
+            homePopupClient: homePopupClient,
+            popupDetailClient: popupDetailClient,
             launchStateResolver: AppLaunchStateResolver(),
             dependencies: dependencies
         )
@@ -40,6 +53,8 @@ struct AppBootstrap {
             )
         } withDependencies: {
             $0.sessionClient = sessionClient
+            $0.homePopupClient = homePopupClient
+            $0.popupDetailClient = popupDetailClient
         }
     }
 }

--- a/Projects/Features/HomeFeature/Sources/Dependency/HomePopupClient.swift
+++ b/Projects/Features/HomeFeature/Sources/Dependency/HomePopupClient.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Domain
 import Foundation
 
-struct HomePopupClient: Sendable {
+public struct HomePopupClient: Sendable {
     var getRegionList: @Sendable () async throws -> [RegionList]
     var getPersonalRandomPopupList: @Sendable (_ userUuid: String) async throws -> [Popup]
     var getPersonalUpcomingPopupList: @Sendable (_ userUuid: String) async throws -> [Popup]
@@ -16,11 +16,13 @@ struct HomePopupClient: Sendable {
     var removeFavorite: @Sendable (_ userUuid: String, _ popupUuid: String) async throws -> Void
 }
 
-extension HomePopupClient: DependencyKey {
-    static var liveValue: HomePopupClient {
-        let box = PopupUsecaseBox(DIContainer.shared.resolve(PopupUsecaseProtocol.self))
+extension HomePopupClient {
+    public static func live(
+        popupUsecase: PopupUsecaseProtocol
+    ) -> Self {
+        let box = PopupUsecaseBox(popupUsecase)
 
-        return HomePopupClient(
+        return Self(
             getRegionList: {
                 try await box.usecase.getRegionList()
             },
@@ -46,9 +48,20 @@ extension HomePopupClient: DependencyKey {
             }
         )
     }
+}
+
+extension HomePopupClient: DependencyKey {
+    public static let liveValue = HomePopupClient(
+        getRegionList: { [] },
+        getPersonalRandomPopupList: { _ in [] },
+        getPersonalUpcomingPopupList: { _ in [] },
+        getPersonalFilteredPopupList: { _, _, _, _ in [] },
+        addFavorite: { _, _ in },
+        removeFavorite: { _, _ in }
+    )
 
 #if DEBUG
-    static var previewValue: HomePopupClient {
+    public static var previewValue: HomePopupClient {
         let popups: [Popup] = [
             .homeFeaturePreview(
                 popupUuid: "preview-1",
@@ -154,7 +167,7 @@ private extension Popup {
 #endif
 
 extension HomePopupClient: TestDependencyKey {
-    static var testValue: HomePopupClient {
+    public static var testValue: HomePopupClient {
         HomePopupClient(
             getRegionList: { [] },
             getPersonalRandomPopupList: { _ in [] },
@@ -167,7 +180,7 @@ extension HomePopupClient: TestDependencyKey {
 }
 
 extension DependencyValues {
-    var homePopupClient: HomePopupClient {
+    public var homePopupClient: HomePopupClient {
         get { self[HomePopupClient.self] }
         set { self[HomePopupClient.self] = newValue }
     }

--- a/Projects/Features/PopupDetailFeature/Sources/Presentation/PopupDetailFeatureReducer.swift
+++ b/Projects/Features/PopupDetailFeature/Sources/Presentation/PopupDetailFeatureReducer.swift
@@ -166,7 +166,7 @@ private extension PopupDetailFeatureReducer {
     }
 }
 
-struct PopupDetailClient: Sendable {
+public struct PopupDetailClient: Sendable {
     var increaseViewCount: @Sendable (_ popupUuid: String) async throws -> Void
     var getPersonalRelatedPopupList: @Sendable (
         _ userUuid: String,
@@ -177,12 +177,15 @@ struct PopupDetailClient: Sendable {
     var deactivatePopup: @Sendable (_ popupUuid: String) async throws -> Void
 }
 
-extension PopupDetailClient: DependencyKey {
-    static var liveValue: PopupDetailClient {
-        let popupUsecaseBox = PopupDetailPopupUsecaseBox(DIContainer.shared.resolve(PopupUsecaseProtocol.self))
-        let adminUsecaseBox = PopupDetailAdminUsecaseBox(DIContainer.shared.resolve(AdminUsecaseProtocol.self))
+extension PopupDetailClient {
+    public static func live(
+        popupUsecase: PopupUsecaseProtocol,
+        adminUsecase: AdminUsecaseProtocol
+    ) -> Self {
+        let popupUsecaseBox = PopupDetailPopupUsecaseBox(popupUsecase)
+        let adminUsecaseBox = PopupDetailAdminUsecaseBox(adminUsecase)
 
-        return PopupDetailClient(
+        return Self(
             increaseViewCount: { popupUuid in
                 try await popupUsecaseBox.usecase.increaseViewCount(popupUuid: popupUuid)
             },
@@ -205,8 +208,18 @@ extension PopupDetailClient: DependencyKey {
     }
 }
 
+extension PopupDetailClient: DependencyKey {
+    public static let liveValue = PopupDetailClient(
+        increaseViewCount: { _ in },
+        getPersonalRelatedPopupList: { _, _ in [] },
+        addFavorite: { _, _ in },
+        removeFavorite: { _, _ in },
+        deactivatePopup: { _ in }
+    )
+}
+
 extension DependencyValues {
-    var popupDetailClient: PopupDetailClient {
+    public var popupDetailClient: PopupDetailClient {
         get { self[PopupDetailClient.self] }
         set { self[PopupDetailClient.self] = newValue }
     }


### PR DESCRIPTION
## 💡 PR 유형
- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [x] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [x] Docs: 문서 작성 및 수정

## ✏️ 변경 사항
- TCA reducer에서 사용하는 HomePopupClient, PopupDetailClient를 AppBootstrap에서 조립해 withDependencies로 주입하도록 정리했습니다.
- TCA dependency 내부에서 DIContainer.shared.resolve(...)를 직접 호출하지 않도록 경계를 분리했습니다.
- legacy Compound는 기존 DIContainer를 유지하고, TCA reducer는 DependencyValues만 사용한다는 기준을 문서에 반영했습니다.
- Docs/poppang-architecture.md, Docs/tca-navigation-guidelines.md에 composition root 주입 기준과 DI 경계 설명을 최신화했습니다.

## 🚨 관련 이슈
- #49 후속 반영

## 🎨 스크린샷
|기능|스크린샷|
|:--:|:--:|
|해당 없음|UI 캡처 변경 없음|

## ✅ 체크리스트
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

### 문제 원인
- 점진적 마이그레이션 중이라 legacy Compound는 DIContainer, TCA reducer는 DependencyValues를 같이 쓰고 있었습니다.
- 그런데 일부 TCA client의 liveValue 내부에서 다시 DIContainer.shared.resolve(...)를 호출하고 있어서, 겉은 TCA dependency지만 실제로는 global service locator를 감싼 형태였습니다.

### 해결 내용
- HomePopupClient, PopupDetailClient에 live(...) 팩토리를 두고 필요한 usecase를 외부에서 주입받도록 변경했습니다.
- AppBootstrap에서 실제 live client를 조립하고 Store.withDependencies로 주입하도록 정리했습니다.
- 이로써 TCA reducer 쪽은 DependencyValues만 보도록 경계를 분리했습니다.

### PopupUsecaseBox 보류 이유
- DIContainer.resolve(...) 의존은 TCA client에서 제거했지만, PopupUsecaseBox 계열은 이번 PR에서 유지했습니다.
- 현재 이 박스들은 @Sendable 클로저 안에서 non-Sendable usecase protocol을 캡처하는 완충 역할을 합니다.
- 완전 제거는 PopupUsecaseProtocol, AdminUsecaseProtocol, 구현체, repository까지 Sendable 전파 범위를 함께 정리해야 해서 이번 PR 범위를 넘는다고 판단했습니다.
- 따라서 이번 PR은 DI 경계 분리에 집중하고, Box 제거는 후속 Sendable 정리 작업으로 분리합니다.

### 검증한 내용
- xcodebuild -quiet -workspace /Users/kimdonghyeon/2025/개발/앱출시/PopPang/PopPang/PopPang.xcworkspace -scheme PopPangApp -destination generic/platform=iOS -derivedDataPath /tmp/PopPangDeviceDerivedData CODE_SIGNING_ALLOWED=NO build 성공
- 기존 TCA macro 기반 Sendable warning은 남아 있지만, 이번 변경으로 새 compile error는 없음을 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 의존성 주입 방식과 TCA 조립 흐름에 대한 안내가 업데이트되어, 새 기능 의존성을 더 명확하게 구성하는 기준이 정리되었습니다.
  * 네비게이션/클라이언트 가이드에서 TCA 클라이언트는 조립 지점에서 주입하는 방식으로 설명이 보강되었습니다.

* **Refactor**
  * 홈 팝업과 팝업 상세 기능의 의존성 구성 방식이 개선되어, 앱 시작 시점에서 필요한 클라이언트를 한 번에 주입하도록 정리되었습니다.
  * TCA용 클라이언트 구성과 기존 방식이 분리되어 구조가 더 일관되게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->