### PR TITLE
[fix] 앱스토어 버전 조회 캐시 문제를 해결하고 ComingPopupDetailFeature 명칭을 정리한다

### DIFF
--- a/Projects/App/Sources/AppCore/VersionUpdateModifier.swift
+++ b/Projects/App/Sources/AppCore/VersionUpdateModifier.swift
@@ -1,9 +1,10 @@
 import Foundation
+import Core
 import SwiftUI
 import UIKit
 
 private enum VersionUpdateConfig {
-    static let lookupURL = URL(string: "https://itunes.apple.com/lookup?id=6753014613&country=KR")
+    static let lookupURL = URL(string: "https://itunes.apple.com/lookup?id=6753014613&country=KR" + "&timestamp=\(Int(Date().timeIntervalSince1970))")
     static let appStoreURL = URL(string: "https://apps.apple.com/app/id6753014613")
 }
 

--- a/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeature.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeature.swift
@@ -3,7 +3,7 @@ import Domain
 import Foundation
 
 @Reducer
-public struct ComingPopupDetailReducer {
+public struct ComingPopupDetailFeature {
     @ObservableState
     public struct State: Equatable, Sendable {
         var userUuid: String
@@ -82,7 +82,7 @@ public struct ComingPopupDetailReducer {
     }
 }
 
-private extension ComingPopupDetailReducer {
+private extension ComingPopupDetailFeature {
     func updateComingPopups(userUuid: String) -> Effect<Action> {
         let popupClient = popupClient
 

--- a/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeatureView.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeatureView.swift
@@ -7,11 +7,11 @@ import SwiftUI
 
 public struct ComingPopupDetailFeatureView: View {
     @Environment(\.dismiss) private var dismiss
-    @Bindable var store: StoreOf<ComingPopupDetailReducer>
+    @Bindable var store: StoreOf<ComingPopupDetailFeature>
     private let onSelectPopup: (String, Popup) -> Void
 
     public init(
-        store: StoreOf<ComingPopupDetailReducer>,
+        store: StoreOf<ComingPopupDetailFeature>,
         onSelectPopup: @escaping (String, Popup) -> Void = { _, _ in }
     ) {
         self.store = store
@@ -25,12 +25,12 @@ public struct ComingPopupDetailFeatureView: View {
     ) {
         self.init(
             store: Store(
-                initialState: ComingPopupDetailReducer.State(
+                initialState: ComingPopupDetailFeature.State(
                     userUuid: userUuid,
                     popups: popups
                 )
             ) {
-                ComingPopupDetailReducer()
+                ComingPopupDetailFeature()
             },
             onSelectPopup: onSelectPopup
         )
@@ -75,11 +75,11 @@ public struct ComingPopupDetailFeatureView: View {
         .updateEngine(.reloadData)
         .scrollIndicators(.hidden)
         .contentInsets(LKEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
-        .overlay {
-            if store.isLoading {
-                HomeFeatureLoadingOverlay()
-            }
-        }
+//        .overlay {
+//            if store.isLoading {
+//                HomeFeatureLoadingOverlay()
+//            }
+//        }
         .alert("안내", isPresented: isComingPopupErrorPresented) {
             Button("확인", role: .cancel) {
                 store.send(.errorMessageChanged(nil))

--- a/Projects/Features/HomeFeature/Sources/Presentation/Home/HomeFeatureDestinations.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/Home/HomeFeatureDestinations.swift
@@ -6,7 +6,7 @@ import SwiftUI
 public struct HomeComingPopupDetailDestinationFeature {
     @ObservableState
     public struct State: Equatable, Identifiable {
-        var content: ComingPopupDetailReducer.State
+        var content: ComingPopupDetailFeature.State
 
         public var id: String { "home-coming-\(content.userUuid)" }
 
@@ -22,7 +22,7 @@ public struct HomeComingPopupDetailDestinationFeature {
     }
 
     public enum Action: Equatable {
-        case content(ComingPopupDetailReducer.Action)
+        case content(ComingPopupDetailFeature.Action)
         case popupSelected(Popup)
         case delegate(Delegate)
 
@@ -35,7 +35,7 @@ public struct HomeComingPopupDetailDestinationFeature {
 
     public var body: some ReducerOf<Self> {
         Scope(state: \.content, action: \.content) {
-            ComingPopupDetailReducer()
+            ComingPopupDetailFeature()
         }
 
         Reduce { _, action in

--- a/V0/PopPang/Sources/App/PopPangApp.swift
+++ b/V0/PopPang/Sources/App/PopPangApp.swift
@@ -217,6 +217,7 @@ struct VersionUpdateModifier: ViewModifier {
         let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         guard let latestVersion = await fetchLatestVersion() else { return }
         
+        Logger.d("버전체크: currentVersion: \(currentVersion), latestVersion: \(latestVersion)")
         if currentVersion.compare(latestVersion, options: .numeric) == .orderedAscending {
             await MainActor.run {
                 self.latestVersion = latestVersion
@@ -229,7 +230,7 @@ struct VersionUpdateModifier: ViewModifier {
         guard let url = URL(string: "https://itunes.apple.com/lookup?id=6753014613&country=KR") else {
             return nil
         }
-        
+        Logger.d("url: \(url)")
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]


### PR DESCRIPTION
## 💡 PR 유형
- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [x] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항
- iTunes Lookup API lookup URL에 `timestamp`를 추가해 앱 재실행 시점마다 다른 요청 URL을 사용하도록 조정했습니다.
- `VersionUpdateModifier`에서 `currentVersion`과 `latestVersion` 로그를 남겨 실제 버전 비교값을 추적할 수 있게 했습니다.
- HomeFeature의 Coming 상세 reducer 파일명과 타입명을 `ComingPopupDetailFeature`로 정리하고 관련 참조를 함께 갱신했습니다.
- Coming 상세 뷰의 로딩 overlay 비활성화 상태를 새 타입명 기준으로 정리했습니다.
- V0 버전 체크 경로에도 동일한 디버그 로그를 추가했습니다.

## 🚨 관련 이슈
- close #56

## 🎨 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [ ] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명
### 문제 원인
- App Store 최신 버전을 조회하는 경로가 고정 lookup URL을 사용하고 있어서, 앱에서 오래된 응답을 받았을 때 실제 최신 버전과 로그 값이 어긋날 수 있었습니다.

### 해결 내용
- `Projects/App/Sources/AppCore/VersionUpdateModifier.swift`의 lookup URL에 `timestamp`를 포함해 앱 재실행 기준으로 새로운 요청 URL이 만들어지도록 했습니다.
- 버전 비교 로그를 추가해 `currentVersion`/`latestVersion` 추적이 가능하도록 했습니다.
- 함께 남아 있던 Coming 상세 feature 명칭 정리와 V0 로그 보강도 같은 브랜치에서 반영했습니다.

### 검증한 내용
- `xcodebuild -workspace PopPang.xcworkspace -scheme PopPangApp -sdk iphonesimulator -derivedDataPath /tmp/PopPangVersionUpdateDerivedData build`를 시도했습니다.
- 현재 변경과 무관하게 `CasePathsMacros`, `ComposableArchitectureMacros`, `PerceptionMacros`, `DependenciesMacrosPlugin` 중복 산출물 오류로 빌드가 실패했습니다.
