### PR TITLE
[fix] 앱스토어 버전 조회 캐시 문제를 해결하고 ComingPopupDetailFeature 명칭을 정리한다

### DIFF
--- a/Projects/App/Sources/AppCore/VersionUpdateModifier.swift
+++ b/Projects/App/Sources/AppCore/VersionUpdateModifier.swift
@@ -1,9 +1,10 @@
 import Foundation
+import Core
 import SwiftUI
 import UIKit
 
 private enum VersionUpdateConfig {
-    static let lookupURL = URL(string: "https://itunes.apple.com/lookup?id=6753014613&country=KR")
+    static let lookupURL = URL(string: "https://itunes.apple.com/lookup?id=6753014613&country=KR" + "&timestamp=\(Int(Date().timeIntervalSince1970))")
     static let appStoreURL = URL(string: "https://apps.apple.com/app/id6753014613")
 }
 

--- a/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeature.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeature.swift
@@ -3,7 +3,7 @@ import Domain
 import Foundation
 
 @Reducer
-public struct ComingPopupDetailReducer {
+public struct ComingPopupDetailFeature {
     @ObservableState
     public struct State: Equatable, Sendable {
         var userUuid: String
@@ -82,7 +82,7 @@ public struct ComingPopupDetailReducer {
     }
 }
 
-private extension ComingPopupDetailReducer {
+private extension ComingPopupDetailFeature {
     func updateComingPopups(userUuid: String) -> Effect<Action> {
         let popupClient = popupClient
 

--- a/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeatureView.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/Coming/ComingPopupDetailFeatureView.swift
@@ -7,11 +7,11 @@ import SwiftUI
 
 public struct ComingPopupDetailFeatureView: View {
     @Environment(\.dismiss) private var dismiss
-    @Bindable var store: StoreOf<ComingPopupDetailReducer>
+    @Bindable var store: StoreOf<ComingPopupDetailFeature>
     private let onSelectPopup: (String, Popup) -> Void
 
     public init(
-        store: StoreOf<ComingPopupDetailReducer>,
+        store: StoreOf<ComingPopupDetailFeature>,
         onSelectPopup: @escaping (String, Popup) -> Void = { _, _ in }
     ) {
         self.store = store
@@ -25,12 +25,12 @@ public struct ComingPopupDetailFeatureView: View {
     ) {
         self.init(
             store: Store(
-                initialState: ComingPopupDetailReducer.State(
+                initialState: ComingPopupDetailFeature.State(
                     userUuid: userUuid,
                     popups: popups
                 )
             ) {
-                ComingPopupDetailReducer()
+                ComingPopupDetailFeature()
             },
             onSelectPopup: onSelectPopup
         )
@@ -75,11 +75,11 @@ public struct ComingPopupDetailFeatureView: View {
         .updateEngine(.reloadData)
         .scrollIndicators(.hidden)
         .contentInsets(LKEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
-        .overlay {
-            if store.isLoading {
-                HomeFeatureLoadingOverlay()
-            }
-        }
+//        .overlay {
+//            if store.isLoading {
+//                HomeFeatureLoadingOverlay()
+//            }
+//        }
         .alert("안내", isPresented: isComingPopupErrorPresented) {
             Button("확인", role: .cancel) {
                 store.send(.errorMessageChanged(nil))

--- a/Projects/Features/HomeFeature/Sources/Presentation/Home/HomeFeatureDestinations.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/Home/HomeFeatureDestinations.swift
@@ -6,7 +6,7 @@ import SwiftUI
 public struct HomeComingPopupDetailDestinationFeature {
     @ObservableState
     public struct State: Equatable, Identifiable {
-        var content: ComingPopupDetailReducer.State
+        var content: ComingPopupDetailFeature.State
 
         public var id: String { "home-coming-\(content.userUuid)" }
 
@@ -22,7 +22,7 @@ public struct HomeComingPopupDetailDestinationFeature {
     }
 
     public enum Action: Equatable {
-        case content(ComingPopupDetailReducer.Action)
+        case content(ComingPopupDetailFeature.Action)
         case popupSelected(Popup)
         case delegate(Delegate)
 
@@ -35,7 +35,7 @@ public struct HomeComingPopupDetailDestinationFeature {
 
     public var body: some ReducerOf<Self> {
         Scope(state: \.content, action: \.content) {
-            ComingPopupDetailReducer()
+            ComingPopupDetailFeature()
         }
 
         Reduce { _, action in

--- a/V0/PopPang/Sources/App/PopPangApp.swift
+++ b/V0/PopPang/Sources/App/PopPangApp.swift
@@ -217,6 +217,7 @@ struct VersionUpdateModifier: ViewModifier {
         let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         guard let latestVersion = await fetchLatestVersion() else { return }
         
+        Logger.d("버전체크: currentVersion: \(currentVersion), latestVersion: \(latestVersion)")
         if currentVersion.compare(latestVersion, options: .numeric) == .orderedAscending {
             await MainActor.run {
                 self.latestVersion = latestVersion
@@ -229,7 +230,7 @@ struct VersionUpdateModifier: ViewModifier {
         guard let url = URL(string: "https://itunes.apple.com/lookup?id=6753014613&country=KR") else {
             return nil
         }
-        
+        Logger.d("url: \(url)")
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]


### PR DESCRIPTION
## 💡 PR 유형
- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [x] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항
- App Store 최신 버전 조회 시 오래된 캐시 응답을 받던 문제를 완화하기 위해 lookup URL에 `timestamp`를 추가했습니다.
- 버전 비교 시점의 `currentVersion`과 `latestVersion`을 로그로 남겨 실제 비교값을 바로 확인할 수 있게 했습니다.
- HomeFeature Coming 상세 reducer/file 명칭을 `ComingPopupDetailFeature`로 정리하고 연결된 참조를 함께 갱신했습니다.
- V0 버전 체크 경로에도 동일한 디버그 로그를 추가했습니다.

## 🚨 관련 이슈
- close #56

## 🎨 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [ ] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명
### 문제 상황
- iTunes Lookup API의 실제 응답은 최신 버전 `1.1.4`였지만, 앱 로그에서는 `latestVersion: 1.1.2`가 찍히는 상황이 있었습니다.
- 당시 앱에 설치된 버전은 `currentVersion: 1.1.4`이어서, 서버 응답이 아니라 캐시된 오래된 lookup 결과를 기준으로 업데이트 필요 여부를 잘못 판단할 여지가 있었습니다.

### 원인
- 버전 조회 경로가 고정 lookup URL을 그대로 사용하고 있었습니다.
- 이 상태에서는 동일한 URL로 반복 조회되면서 캐시된 응답이 재사용될 수 있었고, 그 결과 실제 최신 버전과 로그에 남는 `latestVersion` 값이 어긋날 수 있었습니다.

### 해결 내용
- `Projects/App/Sources/AppCore/VersionUpdateModifier.swift`의 lookup URL에 `timestamp`를 붙여 앱 재실행 시마다 다른 요청 URL이 생성되도록 변경했습니다.
- 이번 변경으로 앱을 다시 실행해 버전 체크가 동작할 때, 이전 lookup 캐시 대신 새 요청 기준으로 최신 버전을 확인하도록 유도했습니다.
- 추가로 `currentVersion`/`latestVersion` 로그를 남겨, 이후에도 `1.1.4` 같은 실제 비교값이 무엇으로 들어오는지 추적할 수 있게 했습니다.

### 함께 반영된 정리
- HomeFeature의 Coming 상세 reducer와 파일명을 `ComingPopupDetailFeature`로 정리했습니다.
- V0 버전 체크 경로에도 동일한 로그를 추가해 비교 흐름을 보기 쉽게 맞췄습니다.

### 검증한 내용
- 로컬 워킹트리는 모두 정리한 상태로 브랜치 `feature/#56`에 커밋/푸시했습니다.
- `xcodebuild -workspace PopPang.xcworkspace -scheme PopPangApp -sdk iphonesimulator -derivedDataPath /tmp/PopPangVersionUpdateDerivedData build`를 시도했습니다.
- 현재 변경과는 별개로 `CasePathsMacros`, `ComposableArchitectureMacros`, `PerceptionMacros`, `DependenciesMacrosPlugin` 중복 산출물 오류로 빌드는 실패했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 앱 버전 확인 요청에 최신 시간 정보가 포함되어, 업데이트 여부를 더 정확하게 조회하도록 개선했습니다.
  * 홈의 팝업 상세 화면에서 로딩 표시 동작을 정리해 화면 전환이 더 자연스러워졌습니다.

* **Refactor**
  * 홈 팝업 상세 관련 구성 요소를 새 이름 체계로 정리해 내부 연결 구조를 일관되게 맞췄습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->