### PR TITLE
[fix] 홈 네비게이션바 액션 버튼 순서를 조정한다

### DIFF
--- a/Projects/Features/HomeFeature/Sources/Presentation/Home/HomeFeatureView.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/Home/HomeFeatureView.swift
@@ -325,14 +325,14 @@ private struct HomeNavigationBar: View {
             }
             .accessibilityIdentifier("home_search_button")
 
-            IconButton {
-                onAlert(userUuid)
-            }
-
             HomeReportButton {
                 onReport()
             }
             .accessibilityIdentifier("home_popup_report_button")
+
+            IconButton {
+                onAlert(userUuid)
+            }
 
             if showsPopupRequestManagement {
                 HomePopupRequestManagementButton {


### PR DESCRIPTION
## 💡 PR 유형
- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항
- `HomeNavigationBar`에서 `HomeReportButton`을 알림 버튼보다 앞에 배치하도록 순서를 조정했습니다.
- 검색, 제보, 알림 버튼의 기존 액션 연결은 유지한 채 홈 상단 액션 버튼 노출 순서만 변경했습니다.

## 🚨 관련 이슈
- close #70

## 🎨 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [ ] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명
- UI 배치 변경만 반영했고, 별도 빌드나 테스트는 진행하지 않았습니다.
- 스크린샷은 별도 첨부가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI 개선**
  * 홈 화면 상단 내비게이션 바에서 신고 버튼이 알림 버튼보다 먼저 표시되도록 순서를 변경했습니다.
  * 기존 버튼 동작과 접근성 설정은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->