### PR TITLE
[#81] README 핵심 성과 가로 구분선을 제거한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ struct PopupListView: View {
 
 -->
 
----
-
 ### **1. 로딩 지연 문제 개선**
 > **문제**  
 > 초기 화면에서 여러 API를 `await`로 순차 호출해, 앞선 요청이 끝난 뒤에 다음 요청이 시작됐음.  
@@ -140,8 +138,6 @@ func getAllPopupData() async {
 }
 ```
 
----
-
 <br><br>
 
 ### **2. Moya를 async/await으로 사용하기 위한 공통 async 래퍼 생성**
@@ -174,8 +170,6 @@ extension MoyaProvider {
 
 let response = try await provider.asyncRequest(.getPopupList)
 ```
-
----
 
 <!--
 ### **3. MainTabFeature에서 Feature 조립과 TCA 네비게이션 통합**
@@ -237,8 +231,6 @@ case .home(.delegate(.searchRequested)):
 
 -->
 
----
-
 <br><br>
 
 ### **3. MVVM에서 TCA로 상태 관리를 마이그레이션**
@@ -253,8 +245,6 @@ case .home(.delegate(.searchRequested)):
 > 🔸 상태 변경 경로를 일관되게 추적할 수 있게 구성<br>
 > 🔸 `EnvironmentObject` 주입 누락으로 발생하던 런타임 크래시를 줄이고 상태 공유 방식을 단순화<br>
 > 🔸 상태 변경을 독립적으로 검증할 수 있어 테스트 용이성 확보
-
----
 
 <br><br>
 
@@ -312,8 +302,6 @@ Projects
     └── ThirdParty
 ```
 
----
-
 <br><br>
 
 ### **5. 외부 SDK 의존성을 ThirdParty 링크 허브로 추적 가능하게 정리**
@@ -345,8 +333,6 @@ Projects
     ]
 )
 ```
-
----
 
 <br><br>
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ func getAllPopupData() async {
 
 ### **2. Moya를 async/await으로 사용하기 위한 공통 async 래퍼 생성**
 > **문제**  
-> Moya는 completion 기반이라 async/await과 직접 호환되지 않아  
-> API마다 동일한 변환 코드가 반복됨  
+> Moya는 completion 기반이라 async/await과 직접 호환되지 않아 API마다 동일한 변환 코드가 반복됨  
 >
 > **해결**  
 > `withCheckedThrowingContinuation` 기반 **공통 async 변환 래퍼** 구현  
@@ -410,5 +409,6 @@ make module LAYER=shared NAME=UIComponents
 - [PopPangListKit](https://github.com/team-PopPang/PopPangListKit): UICollectionView 기반 선언형 목록 라이브러리와 UIKit·SwiftUI 사용 예제
 - `V0/README.md`: 기존 단일 타깃 앱 README
 - `Tuist/Package.swift`: 외부 의존성과 product type 정책
+&amp;nbsp;
 &amp;nbsp;
 &nbsp;


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [x] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- `README.md`의 `# 4. 핵심 성과` 범위에서 가로 구분선(`---`) 7개를 제거했습니다.
- 핵심 성과 1~6번의 섹션 간 `<br><br>` 여백과 본문, 코드 예시는 유지했습니다.

## 🚨 관련 이슈

- close #81

## 🎨 스크린샷

|기능|스크린샷|
|:--:|:--:|
|README 핵심 성과|문서 변경|

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- 문서 변경만 포함하며 `git diff --check`를 통과했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * README의 불필요한 공백 줄을 정리했습니다.
  * 기능, API, 아키텍처 및 기술 성과에 대한 설명 내용은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->