### PR TITLE
[#85] AlertFeature 데모에서 이미지 URL 출처별 prefetch 성능을 비교한다

### DIFF
--- a/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationDemoNavigationView.swift
+++ b/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationDemoNavigationView.swift
@@ -215,7 +215,8 @@ private struct PopupPaginationDemoDestinationView: View {
         case .uiKitReleaseTrigger:
             PopupPaginationUIKitDemoView(
                 store: store,
-                paginationTrigger: .releaseDrivenTargetOffset
+                paginationTrigger: .releaseDrivenTargetOffset,
+                imageSource: .prefetchSample
             )
 
         case .popPangListKit:

--- a/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationDemoNavigationView.swift
+++ b/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationDemoNavigationView.swift
@@ -8,6 +8,7 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
     case uiKitWillEndDragging
     case uiKitReleaseTrigger
     case popPangListKit
+    case uiKitReleaseTriggerPrefetchSample
 
     var title: String {
         switch self {
@@ -21,6 +22,8 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "UIKit + Release Trigger"
         case .popPangListKit:
             "PopPangListKit"
+        case .uiKitReleaseTriggerPrefetchSample:
+            "UIKit + Release Trigger + Picsum"
         }
     }
 
@@ -36,6 +39,8 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "scrollViewWillEndDragging을 주 경로로 사용합니다. scrollViewDidScroll은 감속과 프로그램 이동만 보완합니다."
         case .popPangListKit:
             "List DSL과 내장 pagination 흐름을 확인합니다."
+        case .uiKitReleaseTriggerPrefetchSample:
+            "Release Trigger와 카드 UI는 유지하고, prefetch 예제의 picsum.photos 이미지만 비교합니다."
         }
     }
 
@@ -51,6 +56,8 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "hand.tap"
         case .popPangListKit:
             "square.grid.2x2"
+        case .uiKitReleaseTriggerPrefetchSample:
+            "photo.stack"
         }
     }
 
@@ -66,6 +73,8 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "04"
         case .popPangListKit:
             "05"
+        case .uiKitReleaseTriggerPrefetchSample:
+            "06"
         }
     }
 }
@@ -111,12 +120,12 @@ struct PopupPaginationDemoNavigationView: View {
 private extension PopupPaginationDemoNavigationView {
     var header: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("FIVE WAYS, ONE CURSOR")
+            Text("SIX WAYS, ONE CURSOR")
                 .font(.scdream(.bold, size: 12))
                 .tracking(2.1)
                 .foregroundStyle(Color.mainOrange)
 
-            Text("같은 API를\n다섯 가지 리스트로")
+            Text("같은 API를\n여섯 가지 리스트로")
                 .font(.scdream(.black, size: 30))
                 .foregroundStyle(Color.mainBlack)
                 .lineSpacing(3)
@@ -215,12 +224,18 @@ private struct PopupPaginationDemoDestinationView: View {
         case .uiKitReleaseTrigger:
             PopupPaginationUIKitDemoView(
                 store: store,
-                paginationTrigger: .releaseDrivenTargetOffset,
-                imageSource: .prefetchSample
+                paginationTrigger: .releaseDrivenTargetOffset
             )
 
         case .popPangListKit:
             PopupPaginationListKitDemoView(store: store)
+
+        case .uiKitReleaseTriggerPrefetchSample:
+            PopupPaginationUIKitDemoView(
+                store: store,
+                paginationTrigger: .releaseDrivenTargetOffset,
+                imageSource: .prefetchSample
+            )
         }
     }
 }

--- a/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationDemoNavigationView.swift
+++ b/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationDemoNavigationView.swift
@@ -9,6 +9,8 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
     case uiKitReleaseTrigger
     case popPangListKit
     case uiKitReleaseTriggerPrefetchSample
+    case uiKitImagePreparation
+    case swiftUIImagePreparation
 
     var title: String {
         switch self {
@@ -24,6 +26,10 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "PopPangListKit"
         case .uiKitReleaseTriggerPrefetchSample:
             "UIKit + Release Trigger + Picsum"
+        case .uiKitImagePreparation:
+            "UIKit + Image Preparation"
+        case .swiftUIImagePreparation:
+            "SwiftUI iOS 17 + Image Preparation"
         }
     }
 
@@ -41,6 +47,10 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "List DSL과 내장 pagination 흐름을 확인합니다."
         case .uiKitReleaseTriggerPrefetchSample:
             "Release Trigger와 카드 UI는 유지하고, prefetch 예제의 picsum.photos 이미지만 비교합니다."
+        case .uiKitImagePreparation:
+            "스크롤 비율로 다음 화면의 이미지를 미리 다운샘플링하고 디코드합니다."
+        case .swiftUIImagePreparation:
+            "iOS 17 GeometryReader로 스크롤 비율 prefetch를 실험합니다."
         }
     }
 
@@ -58,6 +68,10 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "square.grid.2x2"
         case .uiKitReleaseTriggerPrefetchSample:
             "photo.stack"
+        case .uiKitImagePreparation:
+            "rectangle.on.rectangle.angled"
+        case .swiftUIImagePreparation:
+            "swiftdata"
         }
     }
 
@@ -75,6 +89,10 @@ enum PopupPaginationDemoRoute: String, CaseIterable, Hashable {
             "05"
         case .uiKitReleaseTriggerPrefetchSample:
             "06"
+        case .uiKitImagePreparation:
+            "07"
+        case .swiftUIImagePreparation:
+            "08"
         }
     }
 }
@@ -125,7 +143,7 @@ private extension PopupPaginationDemoNavigationView {
                 .tracking(2.1)
                 .foregroundStyle(Color.mainOrange)
 
-            Text("같은 API를\n여섯 가지 리스트로")
+            Text("같은 API를\n여덟 가지 리스트로")
                 .font(.scdream(.black, size: 30))
                 .foregroundStyle(Color.mainBlack)
                 .lineSpacing(3)
@@ -236,6 +254,12 @@ private struct PopupPaginationDemoDestinationView: View {
                 paginationTrigger: .releaseDrivenTargetOffset,
                 imageSource: .prefetchSample
             )
+
+        case .uiKitImagePreparation:
+            PopupPaginationUIKitImagePreparationDemoView(store: store)
+
+        case .swiftUIImagePreparation:
+            PopupPaginationSwiftUIImagePreparationDemoView(store: store)
         }
     }
 }

--- a/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationImagePreparationDemoView.swift
+++ b/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationImagePreparationDemoView.swift
@@ -1,0 +1,1067 @@
+import ComposableArchitecture
+import DSKit
+import Foundation
+import ImageIO
+import Kingfisher
+import SwiftUI
+import UIKit
+
+enum PopupPaginationImageExperimentMode: String, CaseIterable, Identifiable {
+    case imageIOPrepared
+    case kingfisherVisible
+    case kingfisherPrefetch
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .imageIOPrepared:
+            "ImageIO"
+        case .kingfisherVisible:
+            "KF 표시"
+        case .kingfisherPrefetch:
+            "KF 선행"
+        }
+    }
+
+    var implementationTitle: String {
+        switch self {
+        case .imageIOPrepared:
+            "IMAGEIO PREPARED"
+        case .kingfisherVisible:
+            "KINGFISHER VISIBLE"
+        case .kingfisherPrefetch:
+            "KINGFISHER PREPARED"
+        }
+    }
+}
+
+@MainActor
+final class PopupPaginationImageExperimentSession {
+    static let thumbnailSize = CGSize(width: 102, height: 126)
+
+    private let imageIOPipeline = PopupPaginationImageIOPipeline(
+        targetSize: thumbnailSize,
+        scale: UIScreen.main.scale
+    )
+    let kingfisherCache = ImageCache(name: "com.poppang.demo.alert.image-lab")
+    private var activeKingfisherPrefetcher: ImagePrefetcher?
+    private var activeKingfisherPrefetchID: UUID?
+    private var pendingKingfisherURLs: [URL] = []
+    private var requestedKingfisherURLs = Set<URL>()
+
+    var kingfisherOptions: KingfisherOptionsInfo {
+        [
+            .processor(DownsamplingImageProcessor(size: Self.thumbnailSize)),
+            .scaleFactor(UIScreen.main.scale),
+            .targetCache(kingfisherCache),
+            .cacheMemoryOnly,
+            .backgroundDecode,
+        ]
+    }
+
+    func prefetch(
+        urls: [URL],
+        mode: PopupPaginationImageExperimentMode
+    ) {
+        switch mode {
+        case .imageIOPrepared:
+            imageIOPipeline.prefetch(urls: urls)
+
+        case .kingfisherVisible:
+            break
+
+        case .kingfisherPrefetch:
+            prefetchWithKingfisher(urls: urls)
+        }
+    }
+
+    func loadImage(
+        at url: URL,
+        completion: @escaping PopupPaginationImageIOPipeline.ImageCompletion
+    ) -> UUID {
+        imageIOPipeline.loadImage(at: url, completion: completion)
+    }
+
+    func cancelImageLoad(_ id: UUID) {
+        imageIOPipeline.cancelImageLoad(id)
+    }
+
+    func reset() {
+        activeKingfisherPrefetcher?.stop()
+        activeKingfisherPrefetcher = nil
+        activeKingfisherPrefetchID = nil
+        pendingKingfisherURLs.removeAll()
+        requestedKingfisherURLs.removeAll()
+        kingfisherCache.clearMemoryCache()
+        imageIOPipeline.reset()
+    }
+}
+
+private extension PopupPaginationImageExperimentSession {
+    func prefetchWithKingfisher(urls: [URL]) {
+        let candidates = urls.filter { requestedKingfisherURLs.insert($0).inserted }
+        guard !candidates.isEmpty else { return }
+
+        pendingKingfisherURLs.append(contentsOf: candidates)
+        startNextKingfisherPrefetchIfNeeded()
+    }
+
+    func startNextKingfisherPrefetchIfNeeded() {
+        guard activeKingfisherPrefetcher == nil, !pendingKingfisherURLs.isEmpty else {
+            return
+        }
+
+        let urls = Array(pendingKingfisherURLs.prefix(6))
+        pendingKingfisherURLs.removeFirst(urls.count)
+        let id = UUID()
+        let prefetcher = ImagePrefetcher(
+            urls: urls,
+            options: kingfisherOptions,
+            completionHandler: { [weak self] _, _, _ in
+                Task { @MainActor in
+                    self?.completeKingfisherPrefetch(id)
+                }
+            }
+        )
+
+        // Keep the comparison aligned with the serial ImageIO decode queue.
+        prefetcher.maxConcurrentDownloads = 1
+        activeKingfisherPrefetchID = id
+        activeKingfisherPrefetcher = prefetcher
+        prefetcher.start()
+    }
+
+    func completeKingfisherPrefetch(_ id: UUID) {
+        guard activeKingfisherPrefetchID == id else { return }
+
+        activeKingfisherPrefetchID = nil
+        activeKingfisherPrefetcher = nil
+        startNextKingfisherPrefetchIfNeeded()
+    }
+}
+
+final class PopupPaginationImageIOPipeline: @unchecked Sendable {
+    typealias ImageCompletion = @MainActor (UIImage?) -> Void
+
+    private struct PendingLoad {
+        let task: URLSessionDataTask
+        var completions: [UUID: ImageCompletion]
+    }
+
+    private let targetSize: CGSize
+    private let scale: CGFloat
+    private let session: URLSession
+    private let decodeQueue = DispatchQueue(
+        label: "com.poppang.demo.alert.image-lab.decode",
+        qos: .utility
+    )
+    private let lock = NSLock()
+    private let maximumCachedImageCount = 36
+
+    private var cachedImages: [URL: UIImage] = [:]
+    private var cachedURLOrder: [URL] = []
+    private var pendingLoads: [URL: PendingLoad] = [:]
+    private var loadURLsByID: [UUID: URL] = [:]
+
+    init(targetSize: CGSize, scale: CGFloat) {
+        self.targetSize = targetSize
+        self.scale = scale
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        self.session = URLSession(configuration: configuration)
+    }
+
+    func prefetch(urls: [URL]) {
+        var tasksToResume: [URLSessionDataTask] = []
+
+        lock.lock()
+        for url in urls where cachedImages[url] == nil && pendingLoads[url] == nil {
+            let task = makeTask(for: url)
+            pendingLoads[url] = PendingLoad(task: task, completions: [:])
+            tasksToResume.append(task)
+        }
+        lock.unlock()
+
+        tasksToResume.forEach { $0.resume() }
+    }
+
+    @discardableResult
+    func loadImage(
+        at url: URL,
+        completion: @escaping ImageCompletion
+    ) -> UUID {
+        let id = UUID()
+        var cachedImage: UIImage?
+        var taskToResume: URLSessionDataTask?
+
+        lock.lock()
+        if let image = cachedImages[url] {
+            cachedImage = image
+        } else if var pendingLoad = pendingLoads[url] {
+            pendingLoad.completions[id] = completion
+            pendingLoads[url] = pendingLoad
+            loadURLsByID[id] = url
+        } else {
+            let task = makeTask(for: url)
+            pendingLoads[url] = PendingLoad(
+                task: task,
+                completions: [id: completion]
+            )
+            loadURLsByID[id] = url
+            taskToResume = task
+        }
+        lock.unlock()
+
+        if let cachedImage {
+            Task { @MainActor in
+                completion(cachedImage)
+            }
+        } else {
+            taskToResume?.resume()
+        }
+
+        return id
+    }
+
+    func cancelImageLoad(_ id: UUID) {
+        lock.lock()
+        if let url = loadURLsByID.removeValue(forKey: id),
+           var pendingLoad = pendingLoads[url]
+        {
+            pendingLoad.completions.removeValue(forKey: id)
+            pendingLoads[url] = pendingLoad
+        }
+        lock.unlock()
+    }
+
+    func reset() {
+        let tasks: [URLSessionDataTask]
+
+        lock.lock()
+        tasks = pendingLoads.values.map(\.task)
+        pendingLoads.removeAll()
+        loadURLsByID.removeAll()
+        cachedImages.removeAll()
+        cachedURLOrder.removeAll()
+        lock.unlock()
+
+        tasks.forEach { $0.cancel() }
+    }
+}
+
+private extension PopupPaginationImageIOPipeline {
+    func makeTask(for url: URL) -> URLSessionDataTask {
+        session.dataTask(with: url) { [weak self] data, response, error in
+            guard let self else { return }
+
+            guard error == nil,
+                  let httpResponse = response as? HTTPURLResponse,
+                  200..<300 ~= httpResponse.statusCode,
+                  let data
+            else {
+                self.complete(url: url, image: nil)
+                return
+            }
+
+            decodeQueue.async { [weak self] in
+                guard let self else { return }
+                let image = Self.downsampledImage(
+                    from: data,
+                    targetSize: self.targetSize,
+                    scale: self.scale
+                )
+                self.complete(url: url, image: image)
+            }
+        }
+    }
+
+    func complete(url: URL, image: UIImage?) {
+        let completions: [ImageCompletion]
+
+        lock.lock()
+        let pendingLoad = pendingLoads.removeValue(forKey: url)
+        completions = pendingLoad.map { Array($0.completions.values) } ?? []
+        pendingLoad?.completions.keys.forEach { loadURLsByID.removeValue(forKey: $0) }
+
+        if let image {
+            cache(image, for: url)
+        }
+        lock.unlock()
+
+        guard !completions.isEmpty else { return }
+        Task { @MainActor in
+            completions.forEach { $0(image) }
+        }
+    }
+
+    func cache(_ image: UIImage, for url: URL) {
+        cachedImages[url] = image
+        cachedURLOrder.removeAll { $0 == url }
+        cachedURLOrder.append(url)
+
+        while cachedURLOrder.count > maximumCachedImageCount {
+            let expiredURL = cachedURLOrder.removeFirst()
+            cachedImages.removeValue(forKey: expiredURL)
+        }
+    }
+
+    static func downsampledImage(
+        from data: Data,
+        targetSize: CGSize,
+        scale: CGFloat
+    ) -> UIImage? {
+        let sourceOptions = [
+            kCGImageSourceShouldCache: false,
+        ] as CFDictionary
+
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+            return nil
+        }
+
+        let maximumPixelSize = max(targetSize.width, targetSize.height) * scale
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maximumPixelSize,
+        ] as CFDictionary
+
+        guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
+            return nil
+        }
+
+        return UIImage(cgImage: image)
+    }
+}
+
+private enum PopupPaginationScrollRatioPrefetchPlanner {
+    private static let cardStride: CGFloat = 162
+    private static let lookAheadViewportRatio: CGFloat = 1.25
+
+    static func urls(
+        items: [PopupPaginationItem],
+        contentOffsetY: CGFloat,
+        viewportHeight: CGFloat
+    ) -> [URL] {
+        guard viewportHeight > 0, !items.isEmpty else { return [] }
+
+        let firstVisibleIndex = max(Int(contentOffsetY / cardStride), 0)
+        let visibleItemCount = max(Int(ceil(viewportHeight / cardStride)), 1)
+        let prefetchItemCount = max(
+            Int(ceil(viewportHeight * lookAheadViewportRatio / cardStride)),
+            1
+        )
+        let startIndex = min(firstVisibleIndex + visibleItemCount, items.count)
+        let endIndex = min(startIndex + prefetchItemCount, items.count)
+
+        guard startIndex < endIndex else { return [] }
+        return items[startIndex..<endIndex].compactMap(\.thumbnailURL)
+    }
+}
+
+private struct PopupPaginationImageExperimentPicker: View {
+    @Binding var mode: PopupPaginationImageExperimentMode
+
+    var body: some View {
+        Picker("이미지 실험 방식", selection: $mode) {
+            ForEach(PopupPaginationImageExperimentMode.allCases) { mode in
+                Text(mode.title).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 10)
+    }
+}
+
+struct PopupPaginationSwiftUIImagePreparationDemoView: View {
+    @Bindable var store: StoreOf<PopupPaginationDemoFeature>
+    @State private var mode: PopupPaginationImageExperimentMode = .imageIOPrepared
+    @State private var imageSession = PopupPaginationImageExperimentSession()
+
+    var body: some View {
+        PopupPaginationDemoScaffold(
+            implementationTitle: "SWIFTUI iOS 17",
+            store: store
+        ) {
+            VStack(spacing: 0) {
+                PopupPaginationImageExperimentPicker(mode: $mode)
+                content
+            }
+        }
+        .task {
+            store.send(.task)
+        }
+        .onChange(of: mode) { _, _ in
+            imageSession.reset()
+        }
+    }
+}
+
+private extension PopupPaginationSwiftUIImagePreparationDemoView {
+    @ViewBuilder
+    var content: some View {
+        if store.isInitialLoading {
+            PopupPaginationLoadingState()
+        } else if !store.hasStarted {
+            PopupPaginationEmptyState(
+                title: "데모 UUID를 확인해 주세요",
+                description: "AlertFeatureDemo.xcconfig의 UUID가 비어 있습니다."
+            )
+        } else if store.items.isEmpty, let errorMessage = store.errorMessage {
+            PopupPaginationErrorState(message: errorMessage) {
+                store.send(.retryTapped)
+            }
+        } else if store.items.isEmpty {
+            PopupPaginationEmptyState(
+                title: "표시할 팝업이 없습니다",
+                description: "API 응답의 items가 비어 있습니다."
+            )
+        } else {
+            popupList
+        }
+    }
+
+    var popupList: some View {
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 0) {
+                    Color.clear
+                        .frame(height: 0)
+                        .background {
+                            GeometryReader { marker in
+                                Color.clear.preference(
+                                    key: PopupPaginationScrollOffsetPreferenceKey.self,
+                                    value: -marker.frame(
+                                        in: .named("image-preparation-scroll")
+                                    ).minY
+                                )
+                            }
+                        }
+
+                    LazyVStack(spacing: 12) {
+                        ForEach(store.items) { item in
+                            PopupPaginationImageExperimentCard(
+                                item: item,
+                                mode: mode,
+                                imageSession: imageSession
+                            )
+                            .task(id: item.id) {
+                                guard item.id == store.items.last?.id else { return }
+                                store.send(.reachedEnd)
+                            }
+                        }
+
+                        PopupPaginationListFooter(
+                            isLoading: store.isLoadingNextPage,
+                            errorMessage: store.errorMessage,
+                            hasNext: store.hasNext
+                        ) {
+                            store.send(.retryTapped)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 4)
+                    .padding(.bottom, 28)
+                }
+            }
+            .coordinateSpace(name: "image-preparation-scroll")
+            .scrollIndicators(.hidden)
+            .onPreferenceChange(PopupPaginationScrollOffsetPreferenceKey.self) { offset in
+                prefetchImages(
+                    contentOffsetY: offset,
+                    viewportHeight: proxy.size.height
+                )
+            }
+            .onAppear {
+                prefetchImages(contentOffsetY: 0, viewportHeight: proxy.size.height)
+            }
+        }
+    }
+
+    func prefetchImages(contentOffsetY: CGFloat, viewportHeight: CGFloat) {
+        let urls = PopupPaginationScrollRatioPrefetchPlanner.urls(
+            items: store.items,
+            contentOffsetY: contentOffsetY,
+            viewportHeight: viewportHeight
+        )
+        imageSession.prefetch(urls: urls, mode: mode)
+    }
+}
+
+private struct PopupPaginationScrollOffsetPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct PopupPaginationImageExperimentCard: View {
+    let item: PopupPaginationItem
+    let mode: PopupPaginationImageExperimentMode
+    let imageSession: PopupPaginationImageExperimentSession
+
+    var body: some View {
+        HStack(spacing: 14) {
+            thumbnail
+                .frame(
+                    width: PopupPaginationImageExperimentSession.thumbnailSize.width,
+                    height: PopupPaginationImageExperimentSession.thumbnailSize.height
+                )
+                .background(Color.mainGray.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Text(item.region)
+                        .font(.scdream(.bold, size: 11))
+                        .foregroundStyle(Color.mainOrange)
+
+                    Spacer()
+
+                    Image(systemName: item.isFavorited ? "heart.fill" : "heart")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(
+                            item.isFavorited ? Color.mainOrange : Color.mainGray
+                        )
+                }
+
+                Text(item.name)
+                    .font(.scdream(.bold, size: 15))
+                    .foregroundStyle(Color.mainBlack)
+                    .lineLimit(2)
+                    .padding(.top, 8)
+
+                Spacer()
+
+                Text("\(item.startDate) - \(item.endDate)")
+                    .font(.scdream(.regular, size: 11))
+                    .foregroundStyle(Color.mainGray)
+                    .lineLimit(1)
+
+                Text(item.popupUuid)
+                    .font(.system(size: 9, weight: .regular, design: .monospaced))
+                    .foregroundStyle(Color.mainGray.opacity(0.7))
+                    .lineLimit(1)
+                    .padding(.top, 5)
+            }
+            .padding(.vertical, 12)
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.mainGray.opacity(0.12), lineWidth: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        switch mode {
+        case .imageIOPrepared:
+            PopupPaginationImageIOThumbnail(
+                url: item.thumbnailURL,
+                imageSession: imageSession
+            )
+
+        case .kingfisherVisible, .kingfisherPrefetch:
+            PopupPaginationKingfisherThumbnail(
+                url: item.thumbnailURL,
+                imageSession: imageSession
+            )
+        }
+    }
+}
+
+private struct PopupPaginationImageIOThumbnail: View {
+    let url: URL?
+    let imageSession: PopupPaginationImageExperimentSession
+
+    @State private var image: UIImage?
+    @State private var loadID: UUID?
+    @State private var requestGeneration = UUID()
+    @State private var didFail = false
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else if didFail || url == nil {
+                fallbackImage
+            } else {
+                ProgressView()
+            }
+        }
+        .onAppear(perform: startLoading)
+        .onDisappear(perform: cancelLoading)
+        .onChange(of: url) { _, _ in
+            cancelLoading()
+            image = nil
+            didFail = false
+            startLoading()
+        }
+    }
+
+    private var fallbackImage: some View {
+        Image(systemName: "photo")
+            .font(.system(size: 22, weight: .light))
+            .foregroundStyle(Color.mainGray)
+    }
+
+    private func startLoading() {
+        guard loadID == nil, image == nil, !didFail, let url else { return }
+
+        let generation = UUID()
+        requestGeneration = generation
+        loadID = imageSession.loadImage(at: url) { loadedImage in
+            guard requestGeneration == generation else { return }
+            image = loadedImage
+            didFail = loadedImage == nil
+            loadID = nil
+        }
+    }
+
+    private func cancelLoading() {
+        requestGeneration = UUID()
+        guard let loadID else { return }
+        imageSession.cancelImageLoad(loadID)
+        self.loadID = nil
+    }
+}
+
+private struct PopupPaginationKingfisherThumbnail: View {
+    let url: URL?
+    let imageSession: PopupPaginationImageExperimentSession
+
+    var body: some View {
+        if let url {
+            KFImage(url)
+                .setProcessor(
+                    DownsamplingImageProcessor(
+                        size: PopupPaginationImageExperimentSession.thumbnailSize
+                    )
+                )
+                .scaleFactor(UIScreen.main.scale)
+                .targetCache(imageSession.kingfisherCache)
+                .cacheMemoryOnly()
+                .backgroundDecode()
+                .placeholder {
+                    ProgressView()
+                }
+                .onFailureView {
+                    Image(systemName: "photo")
+                        .font(.system(size: 22, weight: .light))
+                        .foregroundStyle(Color.mainGray)
+                }
+                .resizable()
+                .scaledToFill()
+        } else {
+            Image(systemName: "photo")
+                .font(.system(size: 22, weight: .light))
+                .foregroundStyle(Color.mainGray)
+        }
+    }
+}
+
+struct PopupPaginationUIKitImagePreparationDemoView: View {
+    @Bindable var store: StoreOf<PopupPaginationDemoFeature>
+    @State private var mode: PopupPaginationImageExperimentMode = .imageIOPrepared
+    @State private var imageSession = PopupPaginationImageExperimentSession()
+
+    var body: some View {
+        PopupPaginationDemoScaffold(
+            implementationTitle: "UIKIT IMAGE LAB",
+            store: store
+        ) {
+            VStack(spacing: 0) {
+                PopupPaginationImageExperimentPicker(mode: $mode)
+                content
+            }
+        }
+        .task {
+            store.send(.task)
+        }
+        .onChange(of: mode) { _, _ in
+            imageSession.reset()
+        }
+    }
+}
+
+private extension PopupPaginationUIKitImagePreparationDemoView {
+    @ViewBuilder
+    var content: some View {
+        if store.isInitialLoading {
+            PopupPaginationLoadingState()
+        } else if !store.hasStarted {
+            PopupPaginationEmptyState(
+                title: "데모 UUID를 확인해 주세요",
+                description: "AlertFeatureDemo.xcconfig의 UUID가 비어 있습니다."
+            )
+        } else if store.items.isEmpty, let errorMessage = store.errorMessage {
+            PopupPaginationErrorState(message: errorMessage) {
+                store.send(.retryTapped)
+            }
+        } else if store.items.isEmpty {
+            PopupPaginationEmptyState(
+                title: "표시할 팝업이 없습니다",
+                description: "API 응답의 items가 비어 있습니다."
+            )
+        } else {
+            PopupPaginationImagePreparationUIKitCollection(
+                items: store.items,
+                canLoadNextPage: store.hasNext
+                    && !store.isRequesting
+                    && store.errorMessage == nil,
+                mode: mode,
+                imageSession: imageSession
+            ) {
+                store.send(.reachedEnd)
+            }
+        }
+    }
+}
+
+private struct PopupPaginationImagePreparationUIKitCollection: UIViewControllerRepresentable {
+    let items: [PopupPaginationItem]
+    let canLoadNextPage: Bool
+    let mode: PopupPaginationImageExperimentMode
+    let imageSession: PopupPaginationImageExperimentSession
+    let onReachedEnd: () -> Void
+
+    func makeUIViewController(context: Context) -> PopupPaginationImagePreparationViewController {
+        PopupPaginationImagePreparationViewController(
+            mode: mode,
+            imageSession: imageSession,
+            onReachedEnd: onReachedEnd
+        )
+    }
+
+    func updateUIViewController(
+        _ viewController: PopupPaginationImagePreparationViewController,
+        context: Context
+    ) {
+        viewController.update(
+            items: items,
+            canLoadNextPage: canLoadNextPage,
+            mode: mode
+        )
+    }
+}
+
+@MainActor
+private final class PopupPaginationImagePreparationViewController: UIViewController {
+    private let imageSession: PopupPaginationImageExperimentSession
+    private let onReachedEnd: () -> Void
+    private let collectionView: UICollectionView
+    private var items: [PopupPaginationItem] = []
+    private var mode: PopupPaginationImageExperimentMode
+    private var canLoadNextPage = false
+
+    init(
+        mode: PopupPaginationImageExperimentMode,
+        imageSession: PopupPaginationImageExperimentSession,
+        onReachedEnd: @escaping () -> Void
+    ) {
+        self.mode = mode
+        self.imageSession = imageSession
+        self.onReachedEnd = onReachedEnd
+        self.collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: Self.makeLayout()
+        )
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.backgroundColor = UIColor(Color.subWhite)
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.register(
+            PopupPaginationImagePreparationCollectionCell.self,
+            forCellWithReuseIdentifier: PopupPaginationImagePreparationCollectionCell.reuseIdentifier
+        )
+
+        view.backgroundColor = UIColor(Color.subWhite)
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    func update(
+        items: [PopupPaginationItem],
+        canLoadNextPage: Bool,
+        mode: PopupPaginationImageExperimentMode
+    ) {
+        self.mode = mode
+        self.items = items
+        self.canLoadNextPage = canLoadNextPage
+        collectionView.reloadData()
+        collectionView.layoutIfNeeded()
+        prefetchImages(contentOffsetY: collectionView.contentOffset.y)
+    }
+}
+
+private extension PopupPaginationImagePreparationViewController {
+    static func makeLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { _, _ in
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(150)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            let group = NSCollectionLayoutGroup.vertical(
+                layoutSize: itemSize,
+                subitems: [item]
+            )
+            let section = NSCollectionLayoutSection(group: group)
+            section.interGroupSpacing = 12
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: 4,
+                leading: 20,
+                bottom: 28,
+                trailing: 20
+            )
+            return section
+        }
+    }
+
+    func prefetchImages(contentOffsetY: CGFloat) {
+        let urls = PopupPaginationScrollRatioPrefetchPlanner.urls(
+            items: items,
+            contentOffsetY: contentOffsetY,
+            viewportHeight: collectionView.bounds.height
+        )
+        imageSession.prefetch(urls: urls, mode: mode)
+    }
+
+    func loadNextPageIfNeeded(contentOffsetY: CGFloat) {
+        guard canLoadNextPage,
+              collectionView.contentSize.height > collectionView.bounds.height
+        else {
+            return
+        }
+
+        let visibleBottom = contentOffsetY + collectionView.bounds.height
+        let triggerOffset = collectionView.contentSize.height - collectionView.bounds.height * 0.75
+        guard visibleBottom >= triggerOffset else { return }
+
+        canLoadNextPage = false
+        onReachedEnd()
+    }
+}
+
+extension PopupPaginationImagePreparationViewController: UICollectionViewDataSource {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        items.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: PopupPaginationImagePreparationCollectionCell.reuseIdentifier,
+            for: indexPath
+        )
+
+        guard let cell = cell as? PopupPaginationImagePreparationCollectionCell else {
+            return cell
+        }
+
+        cell.configure(
+            with: items[indexPath.item],
+            mode: mode,
+            imageSession: imageSession
+        )
+        return cell
+    }
+}
+
+extension PopupPaginationImagePreparationViewController: UICollectionViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        prefetchImages(contentOffsetY: scrollView.contentOffset.y)
+        loadNextPageIfNeeded(contentOffsetY: scrollView.contentOffset.y)
+    }
+
+    func scrollViewWillEndDragging(
+        _ scrollView: UIScrollView,
+        withVelocity velocity: CGPoint,
+        targetContentOffset: UnsafeMutablePointer<CGPoint>
+    ) {
+        let targetOffsetY = targetContentOffset.pointee.y
+        prefetchImages(contentOffsetY: targetOffsetY)
+        loadNextPageIfNeeded(contentOffsetY: targetOffsetY)
+    }
+}
+
+@MainActor
+private final class PopupPaginationImagePreparationCollectionCell: UICollectionViewCell {
+    static let reuseIdentifier = "PopupPaginationImagePreparationCollectionCell"
+
+    private let thumbnailImageView = UIImageView()
+    private let regionLabel = UILabel()
+    private let nameLabel = UILabel()
+    private let dateLabel = UILabel()
+    private let uuidLabel = UILabel()
+    private var imageSession: PopupPaginationImageExperimentSession?
+    private var imageLoadID: UUID?
+    private var imageLoadGeneration = UUID()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureView()
+        configureLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cancelImageLoad()
+        thumbnailImageView.kf.cancelDownloadTask()
+        thumbnailImageView.image = Self.placeholderImage
+        imageSession = nil
+    }
+
+    func configure(
+        with item: PopupPaginationItem,
+        mode: PopupPaginationImageExperimentMode,
+        imageSession: PopupPaginationImageExperimentSession
+    ) {
+        cancelImageLoad()
+        thumbnailImageView.kf.cancelDownloadTask()
+        self.imageSession = imageSession
+        thumbnailImageView.image = Self.placeholderImage
+        regionLabel.text = item.region
+        nameLabel.text = item.name
+        dateLabel.text = "\(item.startDate) - \(item.endDate)"
+        uuidLabel.text = item.popupUuid
+
+        guard let url = item.thumbnailURL else { return }
+
+        switch mode {
+        case .imageIOPrepared:
+            let generation = UUID()
+            imageLoadGeneration = generation
+            imageLoadID = imageSession.loadImage(at: url) { [weak self] image in
+                guard let self, imageLoadGeneration == generation else { return }
+                thumbnailImageView.image = image ?? Self.placeholderImage
+                imageLoadID = nil
+            }
+
+        case .kingfisherVisible, .kingfisherPrefetch:
+            thumbnailImageView.kf.setImage(
+                with: url,
+                placeholder: Self.placeholderImage,
+                options: imageSession.kingfisherOptions
+            )
+        }
+    }
+}
+
+private extension PopupPaginationImagePreparationCollectionCell {
+    static let placeholderImage = UIImage(systemName: "photo")
+
+    func configureView() {
+        backgroundColor = .white
+        layer.cornerRadius = 16
+        layer.cornerCurve = .continuous
+        layer.borderWidth = 1
+        layer.borderColor = UIColor(Color.mainGray.opacity(0.12)).cgColor
+        clipsToBounds = true
+
+        thumbnailImageView.contentMode = .scaleAspectFill
+        thumbnailImageView.clipsToBounds = true
+        thumbnailImageView.layer.cornerRadius = 12
+        thumbnailImageView.layer.cornerCurve = .continuous
+        thumbnailImageView.backgroundColor = UIColor(Color.mainGray.opacity(0.08))
+        thumbnailImageView.tintColor = UIColor(Color.mainGray)
+
+        regionLabel.font = .scdream(.bold, size: 11)
+        regionLabel.textColor = UIColor(Color.mainOrange)
+
+        nameLabel.font = .scdream(.bold, size: 15)
+        nameLabel.textColor = UIColor(Color.mainBlack)
+        nameLabel.numberOfLines = 2
+
+        dateLabel.font = .scdream(.regular, size: 11)
+        dateLabel.textColor = UIColor(Color.mainGray)
+
+        uuidLabel.font = .monospacedSystemFont(ofSize: 9, weight: .regular)
+        uuidLabel.textColor = UIColor(Color.mainGray.opacity(0.7))
+    }
+
+    func configureLayout() {
+        let flexibleSpacer = UIView()
+        flexibleSpacer.setContentHuggingPriority(.defaultLow, for: .vertical)
+
+        let detailStack = UIStackView(arrangedSubviews: [
+            regionLabel,
+            nameLabel,
+            flexibleSpacer,
+            dateLabel,
+            uuidLabel,
+        ])
+        detailStack.axis = .vertical
+        detailStack.alignment = .fill
+        detailStack.spacing = 5
+
+        let contentStack = UIStackView(arrangedSubviews: [
+            thumbnailImageView,
+            detailStack,
+        ])
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.axis = .horizontal
+        contentStack.alignment = .fill
+        contentStack.spacing = 14
+
+        contentView.addSubview(contentStack)
+        NSLayoutConstraint.activate([
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 150),
+            contentStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            contentStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+            contentStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
+            contentStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
+            thumbnailImageView.widthAnchor.constraint(
+                equalToConstant: PopupPaginationImageExperimentSession.thumbnailSize.width
+            ),
+            thumbnailImageView.heightAnchor.constraint(
+                equalToConstant: PopupPaginationImageExperimentSession.thumbnailSize.height
+            ),
+        ])
+    }
+
+    func cancelImageLoad() {
+        imageLoadGeneration = UUID()
+        guard let imageLoadID else { return }
+        imageSession?.cancelImageLoad(imageLoadID)
+        self.imageLoadID = nil
+    }
+}

--- a/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationUIKitDemoView.swift
+++ b/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationUIKitDemoView.swift
@@ -20,17 +20,43 @@ enum PopupPaginationUIKitPaginationTrigger {
     }
 }
 
+enum PopupPaginationUIKitImageSource {
+    case popPang
+    case prefetchSample
+
+    func url(
+        for item: PopupPaginationItem,
+        index: Int
+    ) -> URL? {
+        switch self {
+        case .popPang:
+            item.thumbnailURL
+
+        case .prefetchSample:
+            // 예제 호스트로 팝업 UUID를 보내지 않도록 목록 순번을 고정 seed로 사용한다.
+            URL(
+                string: "https://picsum.photos/seed/basic-prefetch-"
+                    + String(index)
+                    + "/600/400"
+            )
+        }
+    }
+}
+
 struct PopupPaginationUIKitDemoView: View {
     @Bindable var store: StoreOf<PopupPaginationDemoFeature>
     @State private var imagePipeline = PopupPaginationImagePipeline()
     let paginationTrigger: PopupPaginationUIKitPaginationTrigger
+    let imageSource: PopupPaginationUIKitImageSource
 
     init(
         store: StoreOf<PopupPaginationDemoFeature>,
-        paginationTrigger: PopupPaginationUIKitPaginationTrigger = .didScroll
+        paginationTrigger: PopupPaginationUIKitPaginationTrigger = .didScroll,
+        imageSource: PopupPaginationUIKitImageSource = .popPang
     ) {
         self.store = store
         self.paginationTrigger = paginationTrigger
+        self.imageSource = imageSource
     }
 
     var body: some View {
@@ -73,7 +99,8 @@ private extension PopupPaginationUIKitDemoView {
                         && !store.isRequesting
                         && store.errorMessage == nil,
                     imagePipeline: imagePipeline,
-                    paginationTrigger: paginationTrigger
+                    paginationTrigger: paginationTrigger,
+                    imageSource: imageSource
                 ) {
                     store.send(.reachedEnd)
                 }
@@ -96,12 +123,14 @@ private struct PopupPaginationUIKitCollectionView: UIViewControllerRepresentable
     let canLoadNextPage: Bool
     let imagePipeline: PopupPaginationImagePipeline
     let paginationTrigger: PopupPaginationUIKitPaginationTrigger
+    let imageSource: PopupPaginationUIKitImageSource
     let onReachedEnd: () -> Void
 
     func makeUIViewController(context: Context) -> PopupPaginationUIKitViewController {
         PopupPaginationUIKitViewController(
             imagePipeline: imagePipeline,
             paginationTrigger: paginationTrigger,
+            imageSource: imageSource,
             onReachedEnd: onReachedEnd
         )
     }
@@ -126,19 +155,23 @@ private final class PopupPaginationUIKitViewController: UIViewController {
     private let onReachedEnd: () -> Void
     private let imagePipeline: PopupPaginationImagePipeline
     private let paginationTrigger: PopupPaginationUIKitPaginationTrigger
+    private let imageSource: PopupPaginationUIKitImageSource
     private let collectionView: UICollectionView
     private var dataSource: UICollectionViewDiffableDataSource<Section, String>!
     private var itemsByID: [String: PopupPaginationItem] = [:]
+    private var imageURLsByID: [String: URL] = [:]
     private var prefetchTokens: [String: UUID] = [:]
     private var canLoadNextPage = false
 
     init(
         imagePipeline: PopupPaginationImagePipeline,
         paginationTrigger: PopupPaginationUIKitPaginationTrigger,
+        imageSource: PopupPaginationUIKitImageSource,
         onReachedEnd: @escaping () -> Void
     ) {
         self.imagePipeline = imagePipeline
         self.paginationTrigger = paginationTrigger
+        self.imageSource = imageSource
         self.onReachedEnd = onReachedEnd
         self.collectionView = UICollectionView(
             frame: .zero,
@@ -164,6 +197,11 @@ private final class PopupPaginationUIKitViewController: UIViewController {
     ) {
         self.itemsByID = Dictionary(
             uniqueKeysWithValues: items.map { ($0.id, $0) }
+        )
+        self.imageURLsByID = Dictionary(
+            uniqueKeysWithValues: items.enumerated().compactMap { index, item in
+                imageSource.url(for: item, index: index).map { (item.id, $0) }
+            }
         )
         self.canLoadNextPage = canLoadNextPage
 
@@ -239,6 +277,7 @@ private extension PopupPaginationUIKitViewController {
             guard let self, let item = itemsByID[itemID] else { return }
             cell.configure(
                 with: item,
+                thumbnailURL: imageURLsByID[itemID],
                 imagePipeline: imagePipeline
             )
         }
@@ -270,7 +309,7 @@ extension PopupPaginationUIKitViewController: UICollectionViewDataSourcePrefetch
         for indexPath in indexPaths {
             guard let itemID = dataSource.itemIdentifier(for: indexPath),
                   prefetchTokens[itemID] == nil,
-                  let url = itemsByID[itemID]?.thumbnailURL
+                  let url = imageURLsByID[itemID]
             else {
                 continue
             }
@@ -415,10 +454,12 @@ private final class PopupPaginationCollectionViewCell: UICollectionViewCell {
 
     func configure(
         with item: PopupPaginationItem,
+        thumbnailURL: URL?,
         imagePipeline: PopupPaginationImagePipeline
     ) {
         cardView.configure(
             with: item,
+            thumbnailURL: thumbnailURL,
             imagePipeline: imagePipeline
         )
     }
@@ -450,6 +491,7 @@ final class PopupPaginationUIKitCardView: UIView {
 
     func configure(
         with item: PopupPaginationItem,
+        thumbnailURL: URL?,
         imagePipeline: PopupPaginationImagePipeline
     ) {
         cancelImageLoad()
@@ -467,7 +509,7 @@ final class PopupPaginationUIKitCardView: UIView {
             ? UIColor(Color.mainOrange)
             : UIColor(Color.mainGray)
 
-        guard let thumbnailURL = item.thumbnailURL else { return }
+        guard let thumbnailURL else { return }
         let generation = UUID()
         imageLoadGeneration = generation
         imageLoadID = imagePipeline.loadImage(at: thumbnailURL) { [weak self] image in

--- a/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationUIKitDemoView.swift
+++ b/Projects/Features/AlertFeature/Demo/Sources/PopupPaginationUIKitDemoView.swift
@@ -491,6 +491,17 @@ final class PopupPaginationUIKitCardView: UIView {
 
     func configure(
         with item: PopupPaginationItem,
+        imagePipeline: PopupPaginationImagePipeline
+    ) {
+        configure(
+            with: item,
+            thumbnailURL: item.thumbnailURL,
+            imagePipeline: imagePipeline
+        )
+    }
+
+    func configure(
+        with item: PopupPaginationItem,
         thumbnailURL: URL?,
         imagePipeline: PopupPaginationImagePipeline
     ) {


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [x] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- 기존 다섯 개의 pagination 데모와 `UIKit + Release Trigger` 경로는 PopPang 이미지 URL을 그대로 유지했습니다.
- 동일한 Release Trigger와 상세 카드 UI를 사용하는 `UIKit + Release Trigger + Picsum` 여섯 번째 비교 셀을 추가했습니다.
- 새 비교 셀의 prefetch와 셀 표시 요청이 동일한 `imageURLsByID`를 사용하도록 연결했습니다.
- 외부 예제 호스트에 팝업 UUID를 보내지 않도록 목록 순번을 고정 seed로 사용했습니다.
- PopPangListKit 카드가 기존 PopPang 이미지 URL을 계속 사용하도록 `configure` 호환 호출을 복구했습니다.

## 🚨 관련 이슈

- close #85

## 🎨 스크린샷

|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [ ] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

### 검증한 내용

- `git diff --check`를 통과했습니다.
- `tuist build AlertFeatureDemo`는 로컬 React Native 리소스와 설정 파일이 없는 환경에서 Tuist lint 단계에 중단돼 변경 파일의 컴파일 결과를 확인하지 못했습니다.
- SwiftFormat은 현재 환경에 설치되어 있지 않아 실행하지 못했습니다.

### 추가 확인 필요

- 같은 사용자 UUID와 네트워크 조건에서 기존 Release Trigger 및 Picsum 비교 셀을 빠르게 플릭해 이미지 표시 시점과 prefetch 동작을 비교해야 합니다.
- Picsum 경로에서만 지연이 개선될 때 PopPang 이미지 크기와 응답 캐시 정책을 후속으로 조사합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * UIKit 및 SwiftUI 페이지네이션 데모에 이미지 준비·프리패치 샘플 화면을 추가했습니다.
  * 일반 이미지와 고정된 샘플 이미지 소스를 선택할 수 있습니다.
  * 이미지 다운샘플링, 메모리 캐시, 중복 요청 통합 및 취소를 지원합니다.
  * 스크롤 위치와 화면 표시 영역을 기반으로 다음 이미지를 미리 불러옵니다.
  * 이미지 로딩 실패와 셀 재사용 상황을 안정적으로 처리합니다.
  * 페이지네이션 데모 목록이 6개에서 8개로 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->