### PR TITLE
[#91] 프로필 닉네임 변경 후 홈 헤더가 갱신되지 않는 문제를 해결한다

### DIFF
--- a/Projects/Features/HomeFeatureV2/Sources/Presentation/Home/HomeFeatureView.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Presentation/Home/HomeFeatureView.swift
@@ -128,8 +128,8 @@ extension HomeFeatureView {
             }
             .layoutMode(.fitContent(estimatedSize: BestPopupCell.layoutSize))
         }
-        .withHeader(item: "bestPopup") { _ in
-            HomeBestHeader(nickname: store.nickname)
+        .withHeader(item: store.nickname) { nickname in
+            HomeBestHeader(nickname: nickname)
                 .padding(.bottom, 10)
         }
         .headerBackground(UIColor(Color.subWhite))

--- a/Projects/Features/HomeFeatureV2/Tests/HomeFeatureTests.swift
+++ b/Projects/Features/HomeFeatureV2/Tests/HomeFeatureTests.swift
@@ -185,6 +185,17 @@ struct HomeFeatureTests {
         }
     }
 
+    @Test("HomeFeature가 닉네임 갱신 action을 상태에 반영한다")
+    func homeFeatureUpdatesNickname() async {
+        let store = TestStore(initialState: HomeFeature.State(user: makeUser())) {
+            HomeFeature()
+        }
+
+        await store.send(.nicknameUpdated("새 팝팡")) {
+            $0.nickname = "새 팝팡"
+        }
+    }
+
     @Test("HomeFeature가 refreshFilteredPopupList 시 현재 필터로 목록을 다시 조회한다")
     func homeFeatureRefreshesFilteredList() async {
         let region = RegionList(


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [x] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- `HomeFeatureV2`의 베스트 팝업 헤더 item을 고정 값에서 현재 닉네임으로 변경했습니다.
- `PopPangListKit`이 닉네임 변경을 supplementary view 재구성 신호로 인식하도록, 헤더가 전달받은 item을 직접 렌더링했습니다.
- `HomeFeatureV2`의 닉네임 갱신 reducer 회귀 테스트를 추가했습니다.

### 문제 원인

`MainTabFeature`는 프로필 설정의 `.nicknameUpdated` delegate를 받아 홈 상태와 shared session을 정상적으로 갱신하고 있었습니다. 그러나 `HomeFeatureV2`의 `PopPangListKit.Section.withHeader(item:)`은 고정 item을 사용해, 재사용된 UICollectionView 헤더가 새 닉네임으로 구성되지 않았습니다.

### 해결 내용

닉네임을 header item으로 전달해 값이 달라질 때 해당 헤더만 업데이트하도록 수정했습니다. 전체 `PopPangList` 재생성이나 `reloadData`를 사용하지 않아 스크롤 위치, 광고 셀, 다른 섹션의 불필요한 갱신을 피했습니다.

### 검증한 내용

- `HomeFeatureV2Tests`를 실행했습니다.
- `MainTabFeatureTests`를 실행해 프로필 변경 후 홈·프로필·공유 세션의 닉네임 동기화를 확인했습니다.

## 🚨 관련 이슈

- close #91

## 🎨 스크린샷

|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- 검증 명령: `xcodebuild test -workspace PopPang.xcworkspace -scheme HomeFeatureV2 -destination 'id=72A251C3-15A2-4993-846C-57B537164B15' -only-testing:HomeFeatureV2Tests`
- 검증 명령: `xcodebuild test -workspace PopPang.xcworkspace -scheme MainTabFeature -destination 'id=72A251C3-15A2-4993-846C-57B537164B15' -only-testing:MainTabFeatureTests`
- 실제 로그인 계정으로 프로필 닉네임을 변경한 뒤 홈 헤더가 즉시 갱신되는 UI 확인과 스크린샷 첨부는 별도로 필요합니다.
