### PR TITLE
[#93] 네이버 지도 연구용 MapFeatureDemo를 구성한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+# Local secrets. MapFeatureDemo also reads NMFClientID from this file.
 *.xcconfig
+Projects/App/Secrets.xcconfig
 .env
 GoogleService-Info.plist
 

--- a/Projects/Features/MapFeature/Demo/Sources/MapFeatureDemoApp.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/MapFeatureDemoApp.swift
@@ -1,111 +1,36 @@
-import ComposableArchitecture
-import Domain
-import MapFeature
+import NMapsMap
 import SwiftUI
 
 @main
 struct MapFeatureDemoApp: App {
+    init() {
+        MapFeatureDemoConfiguration.configureNaverMap()
+    }
+
     var body: some Scene {
         WindowGroup {
-            MapFeatureView(
-                store: Store(
-                    initialState: MapFeature.State(
-                        userUuid: User.demo.userUuid
-                    )
-                ) {
-                    MapFeature()
-                } withDependencies: {
-                    $0.mapFeatureClient = MapFeatureClient(
-                        getRegionList: {
-                            [
-                                RegionList(region: "전체", districtList: ["전체"]),
-                                RegionList(region: "서울", districtList: ["전체", "성동구", "마포구"]),
-                            ]
-                        },
-                        getPopularRecommendList: {
-                            [
-                                Recommend(id: 1, recommendName: "패션"),
-                                Recommend(id: 2, recommendName: "라이프스타일"),
-                            ]
-                        },
-                        getPopularRecommendPopupList: { _, recommendId in
-                            recommendId == 1 ? [.demo] : [.secondaryDemo]
-                        },
-                        getPersonalMapFilteredPopupList: { _, _, _, _, _, _ in
-                            [.demo, .secondaryDemo]
-                        },
-                        addFavorite: { _, _ in },
-                        removeFavorite: { _, _ in }
-                    )
-                }
-            )
+            NaverMapDemoRootView()
         }
     }
 }
 
-private extension User {
-    static let demo = User(
-        userUuid: "demo-user",
-        uid: "demo-user",
-        provider: "KAKAO",
-        email: nil,
-        nickname: "홍길동",
-        role: "USER",
-        isAlerted: false,
-        fcmToken: nil,
-        alertKeywordList: nil,
-        recommendList: nil
-    )
-}
+enum MapFeatureDemoConfiguration {
+    static var naverMapClientID: String? {
+        guard let clientID = Bundle.main.object(forInfoDictionaryKey: "NMFClientID") as? String else {
+            return nil
+        }
 
-private extension Popup {
-    static let demo = Popup(
-        popupUuid: "map-demo",
-        name: "성수 지도 팝업",
-        startDate: Date(),
-        endDate: Calendar.current.date(byAdding: .day, value: 3, to: Date()) ?? Date(),
-        openTime: "10:00",
-        closeTime: "20:00",
-        address: "서울 성동구 성수동",
-        roadAddress: "서울 성동구 성수동",
-        region: "서울",
-        latitude: 37.544,
-        longitude: 127.055,
-        instaPostId: nil,
-        instaPostUrl: nil,
-        captionSummary: "지도 데모 팝업입니다.",
-        imageUrlList: [
-            "https://poppang.co.kr/images/20251021-165057_18386722330126645/LH_메이커스_스튜디오_팝업스토어_소문내기_이벤트_1.jpg",
-        ],
-        mediaType: .image,
-        favoriteCount: 12,
-        viewCount: 84,
-        isFavorited: false,
-        recommendList: ["패션", "라이프스타일"]
-    )
+        let trimmedClientID = clientID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedClientID.isEmpty == false,
+              trimmedClientID.hasPrefix("$(") == false else {
+            return nil
+        }
 
-    static let secondaryDemo = Popup(
-        popupUuid: "map-demo-2",
-        name: "연남 지도 팝업",
-        startDate: Date(),
-        endDate: Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date(),
-        openTime: "11:00",
-        closeTime: "21:00",
-        address: "서울 마포구 연남동",
-        roadAddress: "서울 마포구 연남동",
-        region: "서울",
-        latitude: 37.561,
-        longitude: 126.923,
-        instaPostId: nil,
-        instaPostUrl: nil,
-        captionSummary: "지도 데모 팝업 2입니다.",
-        imageUrlList: [
-            "https://poppang.co.kr/images/20251021-165057_18386722330126645/LH_메이커스_스튜디오_팝업스토어_소문내기_이벤트_1.jpg",
-        ],
-        mediaType: .image,
-        favoriteCount: 8,
-        viewCount: 42,
-        isFavorited: true,
-        recommendList: ["라이프스타일"]
-    )
+        return trimmedClientID
+    }
+
+    static func configureNaverMap() {
+        guard let naverMapClientID else { return }
+        NMFAuthManager.shared().ncpKeyId = naverMapClientID
+    }
 }

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -1,10 +1,63 @@
+import CoreLocation
 import NMapsMap
 import SwiftUI
+
+/**
+ // 1. SwiftUI가 현재 callback을 NaverMapDemoView에 전달
+ NaverMapDemoView { center in
+     cameraCenter = center
+ }
+
+ // 2. 처음 생성 시, 그 callback을 Coordinator에 전달
+ Coordinator(onCameraCenterChanged: onCameraCenterChanged)
+
+ // 3. 지도 이벤트가 나중에 발생하면 Coordinator가 저장한 callback 실행
+ func mapViewCameraIdle(_ mapView: NMFMapView) {
+     onCameraCenterChanged(center)
+ }
+
+ Coordinator는 NaverMapDemoView보다 오래 살아남을 수 있습니다. SwiftUI는 상태가 바뀔 때 NaverMapDemoView 구조체를 새 값으로 만들지만, 기존 UIKit 지도와 Coordinator는 재사용합니다.
+
+ 그래서 [updateUIView (line 91)](/Users/kimdonghyeon/2025/develop/App/PopPang/PopPang/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift:91)에서 Coordinator의 callback을 최신 값으로 교체합니다.
+
+ NaverMapDemoView의 callback: SwiftUI가 전달한 최신 입력값
+ Coordinator의 callback: UIKit delegate가 실제 이벤트 시점에 실행할 저장값
+
+ SwiftUI 상태만 UIKit에 반영한다
+ → Representable 프로퍼티 + updateUIView
+
+ UIKit 이벤트를 SwiftUI에 전달한다
+ → Representable 프로퍼티 + Coordinator 프로퍼티 + delegate
+
+ UIKit 객체를 계속 보관해야 한다
+ → Coordinator 프로퍼티
+
+
+
+ 1. UIKit 이벤트가 없다, SwiftUI 값만 지도에 적용
+    → Coordinator 없음
+    예: 줌 레벨, 지도 스타일만 SwiftUI에서 설정
+
+ 2. UIKit 이벤트가 있지만 SwiftUI에 알릴 필요가 없다
+    → Coordinator는 필요할 수 있지만 callback 프로퍼티는 없음
+    예: Coordinator 내부에서 마커 캐시만 관리
+
+ 3. UIKit 이벤트를 SwiftUI 상태에 전달해야 한다
+    → NaverMapDemoView와 Coordinator 둘 다 callback 프로퍼티 필요
+    예: 현재 카메라 중심 좌표 전달
+
+ 4. SwiftUI가 다시 렌더링될 때 callback이 바뀔 수 있다
+    → updateUIView에서 Coordinator의 callback 갱신 필요
+    예: 현재 onCameraCenterChanged
+ */
 
 /// 네이버 지도 데모와 카메라 중심 좌표 오버레이를 함께 표시하는 루트 화면입니다.
 struct NaverMapDemoRootView: View {
     /// 마지막으로 카메라 이동이 완료된 지도 중심 좌표입니다.
     @State private var cameraCenter = MapCameraCenter.seoulCityHall
+    @State private var locationRequestID: UUID?
+    @State private var locationErrorMessage = ""
+    @State private var isLocationErrorPresented = false
 
     /// 네이버 지도 키 설정 여부에 따라 지도 또는 설정 안내 화면을 표시합니다.
     var body: some View {
@@ -18,13 +71,32 @@ struct NaverMapDemoRootView: View {
                     )
                 )
             } else {
-                ZStack(alignment: .top) {
-                    NaverMapDemoView { center in
-                        cameraCenter = center
-                    }
+                ZStack {
+                    NaverMapDemoView(
+                        locationRequestID: locationRequestID,
+                        onCameraCenterChanged: { center in
+                            cameraCenter = center
+                        },
+                        onLocationError: { message in
+                            locationErrorMessage = message
+                            isLocationErrorPresented = true
+                        }
+                    )
                     .ignoresSafeArea()
 
                     cameraCenterOverlay
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+
+                    currentLocationButton
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                }
+                .alert(
+                    "현재 위치를 가져올 수 없습니다",
+                    isPresented: $isLocationErrorPresented
+                ) {
+                    Button("확인", role: .cancel) {}
+                } message: {
+                    Text(locationErrorMessage)
                 }
             }
         }
@@ -48,16 +120,40 @@ struct NaverMapDemoRootView: View {
         .padding(.top, 12)
         .allowsHitTesting(false)
     }
+
+    /// 새 위치 요청 토큰을 만들어 Coordinator에 현재 위치 이동을 요청하는 버튼입니다.
+    private var currentLocationButton: some View {
+        Button {
+            locationRequestID = UUID()
+        } label: {
+            Image(systemName: "location.fill")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.primary)
+                .padding(14)
+                .background(.regularMaterial, in: Circle())
+        }
+        .padding(.trailing, 20)
+        .padding(.bottom, 40)
+        .accessibilityLabel("내 위치로 이동")
+    }
 }
 
 /// `NMFNaverMapView`의 카메라 이벤트를 SwiftUI 상태로 연결하는 UIKit 래퍼입니다.
 private struct NaverMapDemoView: UIViewRepresentable {
+    /// SwiftUI 버튼 탭마다 새로 전달되는 현재 위치 이동 요청 식별자입니다.
+    let locationRequestID: UUID?
     /// 카메라 이동이 완료된 뒤 새 중심 좌표를 상위 SwiftUI 화면으로 전달합니다.
     let onCameraCenterChanged: (MapCameraCenter) -> Void
 
+    /// 위치 권한 거부 또는 현재 위치 조회 실패 메시지를 상위 화면으로 전달합니다.
+    let onLocationError: (String) -> Void
+
     /// 네이버 지도 delegate 이벤트를 처리할 Coordinator를 생성합니다.
     func makeCoordinator() -> Coordinator {
-        Coordinator(onCameraCenterChanged: onCameraCenterChanged)
+        Coordinator(
+            onCameraCenterChanged: onCameraCenterChanged,
+            onLocationError: onLocationError
+        )
     }
 
     /// 네이버 지도 UIKit 뷰를 생성하고 고정 옵션과 카메라 delegate를 최초 설정합니다.
@@ -90,32 +186,139 @@ private struct NaverMapDemoView: UIViewRepresentable {
     /// SwiftUI가 갱신될 때 Coordinator가 최신 중심 좌표 callback을 사용하도록 동기화합니다.
     func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
         context.coordinator.onCameraCenterChanged = onCameraCenterChanged
+        context.coordinator.onLocationError = onLocationError
+        context.coordinator.requestCurrentLocationIfNeeded(
+            for: locationRequestID,
+            mapView: uiView.mapView
+        )
     }
 
     /// Representable이 제거될 때 등록했던 카메라 delegate를 해제합니다.
     static func dismantleUIView(_ uiView: NMFNaverMapView, coordinator: Coordinator) {
         uiView.mapView.removeCameraDelegate(delegate: coordinator)
+        coordinator.cancelLocationRequest()
     }
 
     /// 네이버 지도 카메라 delegate 이벤트를 SwiftUI callback으로 변환합니다.
-    final class Coordinator: NSObject, NMFMapViewCameraDelegate {
+    final class Coordinator: NSObject {
         /// 상위 SwiftUI 화면이 제공한 최신 중심 좌표 수신 callback입니다.
         var onCameraCenterChanged: (MapCameraCenter) -> Void
 
-        /// 중심 좌표 callback을 보관하는 Coordinator를 초기화합니다.
-        init(onCameraCenterChanged: @escaping (MapCameraCenter) -> Void) {
+        /// 위치 권한 및 위치 조회 실패를 상위 SwiftUI 화면에 알리는 callback입니다.
+        var onLocationError: (String) -> Void
+
+        private let locationManager = CLLocationManager()
+        private var handledLocationRequestID: UUID?
+        private var isLocationRequestPending = false
+        private weak var mapView: NMFMapView?
+
+        /// 카메라 중심과 위치 오류 callback을 보관하고 위치 관리자 delegate를 연결합니다.
+        init(
+            onCameraCenterChanged: @escaping (MapCameraCenter) -> Void,
+            onLocationError: @escaping (String) -> Void
+        ) {
             self.onCameraCenterChanged = onCameraCenterChanged
+            self.onLocationError = onLocationError
+
+            super.init()
+            locationManager.delegate = self
+            locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
         }
 
-        /// 카메라의 연속 이동과 애니메이션이 끝났을 때 최종 중심 좌표를 전달합니다.
-        func mapViewCameraIdle(_ mapView: NMFMapView) {
-            let target = mapView.cameraPosition.target
-            let center = MapCameraCenter(latitude: target.lat, longitude: target.lng)
+        /// 새로운 요청 식별자가 전달된 경우에만 권한 상태에 맞춰 현재 위치 조회를 시작합니다.
+        func requestCurrentLocationIfNeeded(
+            for requestID: UUID?,
+            mapView: NMFMapView
+        ) {
+            guard let requestID,
+                  requestID != handledLocationRequestID else {
+                return
+            }
 
-            DispatchQueue.main.async { [weak self] in
-                self?.onCameraCenterChanged(center)
+            handledLocationRequestID = requestID
+            isLocationRequestPending = true
+            self.mapView = mapView
+
+            switch locationManager.authorizationStatus {
+            case .authorizedAlways, .authorizedWhenInUse:
+                locationManager.requestLocation()
+            case .notDetermined:
+                locationManager.requestWhenInUseAuthorization()
+            case .denied, .restricted:
+                reportLocationError("위치 권한을 허용한 뒤 다시 시도해 주세요.")
+            @unknown default:
+                reportLocationError("현재 위치 권한 상태를 확인할 수 없습니다.")
             }
         }
+
+        /// 화면 제거 시 대기 중인 위치 요청과 지도 참조를 정리합니다.
+        func cancelLocationRequest() {
+            isLocationRequestPending = false
+            mapView = nil
+        }
+
+        /// 위치 관련 오류를 다음 SwiftUI 업데이트 사이클에서 상위 화면으로 전달합니다.
+        private func reportLocationError(_ message: String) {
+            isLocationRequestPending = false
+
+            DispatchQueue.main.async { [weak self] in
+                self?.onLocationError(message)
+            }
+        }
+    }
+}
+
+extension NaverMapDemoView.Coordinator: NMFMapViewCameraDelegate {
+    /// 카메라의 연속 이동과 애니메이션이 끝났을 때 최종 중심 좌표를 전달합니다.
+    func mapViewCameraIdle(_ mapView: NMFMapView) {
+        let target = mapView.cameraPosition.target
+        let center = MapCameraCenter(latitude: target.lat, longitude: target.lng)
+
+        DispatchQueue.main.async { [weak self] in
+            self?.onCameraCenterChanged(center)
+        }
+    }
+}
+
+extension NaverMapDemoView.Coordinator: CLLocationManagerDelegate {
+    /// 권한 상태가 바뀐 뒤 대기 중인 요청이 있으면 위치 조회를 재개하거나 오류를 알립니다.
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        guard isLocationRequestPending else { return }
+
+        switch manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            manager.requestLocation()
+        case .denied, .restricted:
+            reportLocationError("위치 권한을 허용한 뒤 다시 시도해 주세요.")
+        case .notDetermined:
+            break
+        @unknown default:
+            reportLocationError("현재 위치 권한 상태를 확인할 수 없습니다.")
+        }
+    }
+
+    /// 현재 위치를 받은 뒤 해당 좌표로 네이버 지도 카메라를 이동합니다.
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard isLocationRequestPending,
+              let location = locations.last,
+              let mapView else {
+            return
+        }
+
+        isLocationRequestPending = false
+
+        let coordinate = NMGLatLng(
+            lat: location.coordinate.latitude,
+            lng: location.coordinate.longitude
+        )
+        let update = NMFCameraUpdate(scrollTo: coordinate, zoomTo: 15)
+        update.animation = .easeIn
+        mapView.moveCamera(update)
+    }
+
+    /// 위치 조회 실패를 사용자에게 안내할 수 있도록 상위 SwiftUI 화면에 전달합니다.
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        reportLocationError("현재 위치를 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.")
     }
 }
 

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -2,6 +2,8 @@ import NMapsMap
 import SwiftUI
 
 struct NaverMapDemoRootView: View {
+    @State private var cameraCenter = MapCameraCenter.seoulCityHall
+
     var body: some View {
         Group {
             if MapFeatureDemoConfiguration.naverMapClientID == nil {
@@ -13,14 +15,44 @@ struct NaverMapDemoRootView: View {
                     )
                 )
             } else {
-                NaverMapDemoView()
+                ZStack(alignment: .top) {
+                    NaverMapDemoView { center in
+                        cameraCenter = center
+                    }
                     .ignoresSafeArea()
+
+                    cameraCenterOverlay
+                }
             }
         }
+    }
+
+    private var cameraCenterOverlay: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("카메라 중심")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Text(
+                "위도 \(cameraCenter.latitude, format: .number.precision(.fractionLength(6)))  경도 \(cameraCenter.longitude, format: .number.precision(.fractionLength(6)))"
+            )
+            .font(.callout.monospacedDigit().weight(.medium))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .padding(.top, 12)
+        .allowsHitTesting(false)
     }
 }
 
 private struct NaverMapDemoView: UIViewRepresentable {
+    let onCameraCenterChanged: (MapCameraCenter) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCameraCenterChanged: onCameraCenterChanged)
+    }
+
     func makeUIView(context: Context) -> NMFNaverMapView {
         let naverMapView = NMFNaverMapView(frame: .zero)
         let mapView = naverMapView.mapView
@@ -31,17 +63,54 @@ private struct NaverMapDemoView: UIViewRepresentable {
         mapView.isNightModeEnabled = false
         mapView.logoAlign = .leftBottom
         mapView.logoMargin = UIEdgeInsets(top: 0, left: 20, bottom: 20, right: 0)
+        mapView.addCameraDelegate(delegate: context.coordinator)
 
         naverMapView.showCompass = true
         naverMapView.showLocationButton = false
         naverMapView.showScaleBar = false
         naverMapView.showZoomControls = false
 
-        let seoulCityHall = NMGLatLng(lat: 37.5665, lng: 126.9780)
+        let seoulCityHall = NMGLatLng(
+            lat: MapCameraCenter.seoulCityHall.latitude,
+            lng: MapCameraCenter.seoulCityHall.longitude
+        )
         mapView.moveCamera(NMFCameraUpdate(scrollTo: seoulCityHall))
 
         return naverMapView
     }
 
-    func updateUIView(_ uiView: NMFNaverMapView, context: Context) {}
+    func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
+        context.coordinator.onCameraCenterChanged = onCameraCenterChanged
+    }
+
+    static func dismantleUIView(_ uiView: NMFNaverMapView, coordinator: Coordinator) {
+        uiView.mapView.removeCameraDelegate(delegate: coordinator)
+    }
+
+    final class Coordinator: NSObject, NMFMapViewCameraDelegate {
+        var onCameraCenterChanged: (MapCameraCenter) -> Void
+
+        init(onCameraCenterChanged: @escaping (MapCameraCenter) -> Void) {
+            self.onCameraCenterChanged = onCameraCenterChanged
+        }
+
+        func mapViewCameraIdle(_ mapView: NMFMapView) {
+            let target = mapView.cameraPosition.target
+            let center = MapCameraCenter(latitude: target.lat, longitude: target.lng)
+
+            DispatchQueue.main.async { [weak self] in
+                self?.onCameraCenterChanged(center)
+            }
+        }
+    }
+}
+
+private struct MapCameraCenter: Equatable {
+    let latitude: Double
+    let longitude: Double
+
+    static let seoulCityHall = MapCameraCenter(
+        latitude: 37.5665,
+        longitude: 126.9780
+    )
 }

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -50,6 +50,12 @@ import UIKit
  4. SwiftUI가 다시 렌더링될 때 callback이 바뀔 수 있다
     → updateUIView에서 Coordinator의 callback 갱신 필요
     예: 현재 onCameraCenterChanged
+
+ // 우리 앱 일반 설정
+ openURL(URL(string: UIApplication.openSettingsURLString)!)
+
+ // 우리 앱 알림 설정
+ openURL(URL(string: UIApplication.openNotificationSettingsURLString)!)
  */
 
 /// 네이버 지도 데모와 카메라 중심 좌표 오버레이를 함께 표시하는 루트 화면입니다.
@@ -343,6 +349,13 @@ extension NaverMapDemoView.Coordinator: CLLocationManagerDelegate {
             lat: location.coordinate.latitude,
             lng: location.coordinate.longitude
         )
+
+        // 네이버 기본 내 위치 마커를 현재 수신한 좌표로 이동합니다.
+        mapView.locationOverlay.location = coordinate
+
+        // 기본 내 위치 마커가 숨겨져 있으면 지도에 표시합니다.
+        mapView.locationOverlay.hidden = false
+
         let update = NMFCameraUpdate(scrollTo: coordinate, zoomTo: 15)
         update.animation = .easeIn
         mapView.moveCamera(update)

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -148,7 +148,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
     /// 위치 권한 거부 또는 현재 위치 조회 실패 메시지를 상위 화면으로 전달합니다.
     let onLocationError: (String) -> Void
 
-    /// 네이버 지도 delegate 이벤트를 처리할 Coordinator를 생성합니다.
+    /// UIViewRepresentable 메서드 - 네이버 지도 delegate 이벤트를 처리할 Coordinator를 생성합니다.
     func makeCoordinator() -> Coordinator {
         Coordinator(
             onCameraCenterChanged: onCameraCenterChanged,
@@ -156,7 +156,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
         )
     }
 
-    /// 네이버 지도 UIKit 뷰를 생성하고 고정 옵션과 카메라 delegate를 최초 설정합니다.
+    /// UIViewRepresentable 메서드 - 네이버 지도 UIKit 뷰를 생성하고 고정 옵션과 카메라 delegate를 최초 설정합니다.
     func makeUIView(context: Context) -> NMFNaverMapView {
         let naverMapView = NMFNaverMapView(frame: .zero)
         let mapView = naverMapView.mapView
@@ -183,7 +183,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
         return naverMapView
     }
 
-    /// SwiftUI가 갱신될 때 Coordinator가 최신 중심 좌표 callback을 사용하도록 동기화합니다.
+    /// UIViewRepresentable 메서드 - SwiftUI가 갱신될 때 Coordinator가 최신 callback을 사용하도록 동기화합니다.
     func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
         context.coordinator.onCameraCenterChanged = onCameraCenterChanged
         context.coordinator.onLocationError = onLocationError
@@ -193,7 +193,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
         )
     }
 
-    /// Representable이 제거될 때 등록했던 카메라 delegate를 해제합니다.
+    /// UIViewRepresentable 메서드 - Representable이 제거될 때 등록했던 카메라 delegate를 해제합니다.
     static func dismantleUIView(_ uiView: NMFNaverMapView, coordinator: Coordinator) {
         uiView.mapView.removeCameraDelegate(delegate: coordinator)
         coordinator.cancelLocationRequest()
@@ -212,7 +212,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
         private var isLocationRequestPending = false
         private weak var mapView: NMFMapView?
 
-        /// 카메라 중심과 위치 오류 callback을 보관하고 위치 관리자 delegate를 연결합니다.
+        /// 초기화 메서드 - 카메라 중심과 위치 오류 callback을 보관하고 위치 관리자 delegate를 연결합니다.
         init(
             onCameraCenterChanged: @escaping (MapCameraCenter) -> Void,
             onLocationError: @escaping (String) -> Void
@@ -225,7 +225,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
             locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
         }
 
-        /// 새로운 요청 식별자가 전달된 경우에만 권한 상태에 맞춰 현재 위치 조회를 시작합니다.
+        /// 사용자 정의 메서드 - 새 요청 식별자에 대해 권한 상태에 맞춰 현재 위치 조회를 시작합니다.
         func requestCurrentLocationIfNeeded(
             for requestID: UUID?,
             mapView: NMFMapView
@@ -251,13 +251,13 @@ private struct NaverMapDemoView: UIViewRepresentable {
             }
         }
 
-        /// 화면 제거 시 대기 중인 위치 요청과 지도 참조를 정리합니다.
+        /// 사용자 정의 메서드 - 화면 제거 시 대기 중인 위치 요청과 지도 참조를 정리합니다.
         func cancelLocationRequest() {
             isLocationRequestPending = false
             mapView = nil
         }
 
-        /// 위치 관련 오류를 다음 SwiftUI 업데이트 사이클에서 상위 화면으로 전달합니다.
+        /// 사용자 정의 메서드 - 위치 관련 오류를 다음 SwiftUI 업데이트 사이클에서 상위 화면으로 전달합니다.
         private func reportLocationError(_ message: String) {
             isLocationRequestPending = false
 
@@ -269,7 +269,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
 }
 
 extension NaverMapDemoView.Coordinator: NMFMapViewCameraDelegate {
-    /// 카메라의 연속 이동과 애니메이션이 끝났을 때 최종 중심 좌표를 전달합니다.
+    /// NMFMapViewCameraDelegate 메서드 - 카메라 이동과 애니메이션이 끝났을 때 최종 중심 좌표를 전달합니다.
     func mapViewCameraIdle(_ mapView: NMFMapView) {
         let target = mapView.cameraPosition.target
         let center = MapCameraCenter(latitude: target.lat, longitude: target.lng)
@@ -281,7 +281,7 @@ extension NaverMapDemoView.Coordinator: NMFMapViewCameraDelegate {
 }
 
 extension NaverMapDemoView.Coordinator: CLLocationManagerDelegate {
-    /// 권한 상태가 바뀐 뒤 대기 중인 요청이 있으면 위치 조회를 재개하거나 오류를 알립니다.
+    /// CLLocationManagerDelegate 메서드 - 권한 상태가 바뀐 뒤 대기 중인 요청을 재개하거나 오류를 알립니다.
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         guard isLocationRequestPending else { return }
 
@@ -297,7 +297,7 @@ extension NaverMapDemoView.Coordinator: CLLocationManagerDelegate {
         }
     }
 
-    /// 현재 위치를 받은 뒤 해당 좌표로 네이버 지도 카메라를 이동합니다.
+    /// CLLocationManagerDelegate 메서드 - 현재 위치를 받은 뒤 해당 좌표로 네이버 지도 카메라를 이동합니다.
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard isLocationRequestPending,
               let location = locations.last,
@@ -316,7 +316,7 @@ extension NaverMapDemoView.Coordinator: CLLocationManagerDelegate {
         mapView.moveCamera(update)
     }
 
-    /// 위치 조회 실패를 사용자에게 안내할 수 있도록 상위 SwiftUI 화면에 전달합니다.
+    /// CLLocationManagerDelegate 메서드 - 위치 조회 실패를 상위 SwiftUI 화면에 전달합니다.
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         reportLocationError("현재 위치를 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.")
     }

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -1,6 +1,7 @@
 import CoreLocation
 import NMapsMap
 import SwiftUI
+import UIKit
 
 /**
  // 1. SwiftUI가 현재 callback을 NaverMapDemoView에 전달
@@ -53,11 +54,12 @@ import SwiftUI
 
 /// 네이버 지도 데모와 카메라 중심 좌표 오버레이를 함께 표시하는 루트 화면입니다.
 struct NaverMapDemoRootView: View {
+    @Environment(\.openURL) private var openURL
+
     /// 마지막으로 카메라 이동이 완료된 지도 중심 좌표입니다.
     @State private var cameraCenter = MapCameraCenter.seoulCityHall
     @State private var locationRequestID: UUID?
-    @State private var locationErrorMessage = ""
-    @State private var isLocationErrorPresented = false
+    @State private var locationFailure: LocationFailure?
 
     /// 네이버 지도 키 설정 여부에 따라 지도 또는 설정 안내 화면을 표시합니다.
     var body: some View {
@@ -77,9 +79,8 @@ struct NaverMapDemoRootView: View {
                         onCameraCenterChanged: { center in
                             cameraCenter = center
                         },
-                        onLocationError: { message in
-                            locationErrorMessage = message
-                            isLocationErrorPresented = true
+                        onLocationError: { failure in
+                            locationFailure = failure
                         }
                     )
                     .ignoresSafeArea()
@@ -91,12 +92,27 @@ struct NaverMapDemoRootView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                 }
                 .alert(
-                    "현재 위치를 가져올 수 없습니다",
-                    isPresented: $isLocationErrorPresented
+                    locationFailure?.title ?? "현재 위치를 가져올 수 없습니다",
+                    isPresented: Binding(
+                        get: { locationFailure != nil },
+                        set: { isPresented in
+                            if isPresented == false {
+                                locationFailure = nil
+                            }
+                        }
+                    )
                 ) {
-                    Button("확인", role: .cancel) {}
+                    if locationFailure?.requiresSettings == true {
+                        Button("설정으로 이동") {
+                            openAppSettings()
+                        }
+                    }
+
+                    Button("확인", role: .cancel) {
+                        locationFailure = nil
+                    }
                 } message: {
-                    Text(locationErrorMessage)
+                    Text(locationFailure?.message ?? "")
                 }
             }
         }
@@ -136,6 +152,15 @@ struct NaverMapDemoRootView: View {
         .padding(.bottom, 40)
         .accessibilityLabel("내 위치로 이동")
     }
+
+    /// 앱 설정 화면을 열어 사용자가 위치 권한을 직접 변경할 수 있게 합니다.
+    private func openAppSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+
+        openURL(settingsURL)
+    }
 }
 
 /// `NMFNaverMapView`의 카메라 이벤트를 SwiftUI 상태로 연결하는 UIKit 래퍼입니다.
@@ -145,8 +170,8 @@ private struct NaverMapDemoView: UIViewRepresentable {
     /// 카메라 이동이 완료된 뒤 새 중심 좌표를 상위 SwiftUI 화면으로 전달합니다.
     let onCameraCenterChanged: (MapCameraCenter) -> Void
 
-    /// 위치 권한 거부 또는 현재 위치 조회 실패 메시지를 상위 화면으로 전달합니다.
-    let onLocationError: (String) -> Void
+    /// 위치 권한 거부 또는 현재 위치 조회 실패 상태를 상위 화면으로 전달합니다.
+    let onLocationError: (LocationFailure) -> Void
 
     /// UIViewRepresentable 메서드 - 네이버 지도 delegate 이벤트를 처리할 Coordinator를 생성합니다.
     func makeCoordinator() -> Coordinator {
@@ -205,7 +230,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
         var onCameraCenterChanged: (MapCameraCenter) -> Void
 
         /// 위치 권한 및 위치 조회 실패를 상위 SwiftUI 화면에 알리는 callback입니다.
-        var onLocationError: (String) -> Void
+        var onLocationError: (LocationFailure) -> Void
 
         /// 위치 권한을 요청하고 한 번의 현재 위치를 수신하는 Core Location 관리자입니다.
         private let locationManager = CLLocationManager()
@@ -222,7 +247,7 @@ private struct NaverMapDemoView: UIViewRepresentable {
         /// 초기화 메서드 - 카메라 중심과 위치 오류 callback을 보관하고 위치 관리자 delegate를 연결합니다.
         init(
             onCameraCenterChanged: @escaping (MapCameraCenter) -> Void,
-            onLocationError: @escaping (String) -> Void
+            onLocationError: @escaping (LocationFailure) -> Void
         ) {
             self.onCameraCenterChanged = onCameraCenterChanged
             self.onLocationError = onLocationError
@@ -252,9 +277,9 @@ private struct NaverMapDemoView: UIViewRepresentable {
             case .notDetermined:
                 locationManager.requestWhenInUseAuthorization()
             case .denied, .restricted:
-                reportLocationError("위치 권한을 허용한 뒤 다시 시도해 주세요.")
+                reportLocationError(.permissionDenied)
             @unknown default:
-                reportLocationError("현재 위치 권한 상태를 확인할 수 없습니다.")
+                reportLocationError(.unavailable)
             }
         }
 
@@ -265,11 +290,11 @@ private struct NaverMapDemoView: UIViewRepresentable {
         }
 
         /// 사용자 정의 메서드 - 위치 관련 오류를 다음 SwiftUI 업데이트 사이클에서 상위 화면으로 전달합니다.
-        private func reportLocationError(_ message: String) {
+        private func reportLocationError(_ failure: LocationFailure) {
             isLocationRequestPending = false
 
             DispatchQueue.main.async { [weak self] in
-                self?.onLocationError(message)
+                self?.onLocationError(failure)
             }
         }
     }
@@ -296,11 +321,11 @@ extension NaverMapDemoView.Coordinator: CLLocationManagerDelegate {
         case .authorizedAlways, .authorizedWhenInUse:
             manager.requestLocation()
         case .denied, .restricted:
-            reportLocationError("위치 권한을 허용한 뒤 다시 시도해 주세요.")
+            reportLocationError(.permissionDenied)
         case .notDetermined:
             break
         @unknown default:
-            reportLocationError("현재 위치 권한 상태를 확인할 수 없습니다.")
+            reportLocationError(.unavailable)
         }
     }
 
@@ -325,7 +350,35 @@ extension NaverMapDemoView.Coordinator: CLLocationManagerDelegate {
 
     /// CLLocationManagerDelegate 메서드 - 위치 조회 실패를 상위 SwiftUI 화면에 전달합니다.
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        reportLocationError("현재 위치를 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.")
+        reportLocationError(.unavailable)
+    }
+}
+
+/// 현재 위치 이동 실패의 원인에 맞는 사용자 안내를 정의합니다.
+private enum LocationFailure {
+    case permissionDenied
+    case unavailable
+
+    var title: String {
+        switch self {
+        case .permissionDenied:
+            "위치 권한이 필요합니다"
+        case .unavailable:
+            "현재 위치를 가져올 수 없습니다"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .permissionDenied:
+            "현재 위치로 이동하려면 설정에서 위치 권한을 허용해 주세요."
+        case .unavailable:
+            "잠시 후 다시 시도해 주세요."
+        }
+    }
+
+    var requiresSettings: Bool {
+        self == .permissionDenied
     }
 }
 

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -1,0 +1,47 @@
+import NMapsMap
+import SwiftUI
+
+struct NaverMapDemoRootView: View {
+    var body: some View {
+        Group {
+            if MapFeatureDemoConfiguration.naverMapClientID == nil {
+                ContentUnavailableView(
+                    "네이버 지도 키가 필요합니다",
+                    systemImage: "key.horizontal",
+                    description: Text(
+                        "Projects/App/Secrets.xcconfig에 NMFClientID를 설정한 뒤 다시 실행해 주세요."
+                    )
+                )
+            } else {
+                NaverMapDemoView()
+                    .ignoresSafeArea()
+            }
+        }
+    }
+}
+
+private struct NaverMapDemoView: UIViewRepresentable {
+    func makeUIView(context: Context) -> NMFNaverMapView {
+        let naverMapView = NMFNaverMapView(frame: .zero)
+        let mapView = naverMapView.mapView
+
+        mapView.zoomLevel = 15
+        mapView.minZoomLevel = 5
+        mapView.maxZoomLevel = 20
+        mapView.isNightModeEnabled = false
+        mapView.logoAlign = .leftBottom
+        mapView.logoMargin = UIEdgeInsets(top: 0, left: 20, bottom: 20, right: 0)
+
+        naverMapView.showCompass = true
+        naverMapView.showLocationButton = false
+        naverMapView.showScaleBar = false
+        naverMapView.showZoomControls = false
+
+        let seoulCityHall = NMGLatLng(lat: 37.5665, lng: 126.9780)
+        mapView.moveCamera(NMFCameraUpdate(scrollTo: seoulCityHall))
+
+        return naverMapView
+    }
+
+    func updateUIView(_ uiView: NMFNaverMapView, context: Context) {}
+}

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -97,6 +97,9 @@ struct NaverMapDemoRootView: View {
                     currentLocationButton
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                 }
+                .onAppear {
+                    requestInitialLocationIfAuthorized()
+                }
                 .alert(
                     locationFailure?.title ?? "현재 위치를 가져올 수 없습니다",
                     isPresented: Binding(
@@ -157,6 +160,20 @@ struct NaverMapDemoRootView: View {
         .padding(.trailing, 20)
         .padding(.bottom, 40)
         .accessibilityLabel("내 위치로 이동")
+    }
+
+    /// 사용자 정의 메서드 - 앱 시작 시 위치 권한이 이미 허용된 경우에만 자동 위치 이동을 요청합니다.
+    private func requestInitialLocationIfAuthorized() {
+        guard locationRequestID == nil else { return }
+
+        switch CLLocationManager().authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            locationRequestID = UUID()
+        case .notDetermined, .denied, .restricted:
+            break
+        @unknown default:
+            break
+        }
     }
 
     /// 앱 설정 화면을 열어 사용자가 위치 권한을 직접 변경할 수 있게 합니다.

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -1,9 +1,12 @@
 import NMapsMap
 import SwiftUI
 
+/// 네이버 지도 데모와 카메라 중심 좌표 오버레이를 함께 표시하는 루트 화면입니다.
 struct NaverMapDemoRootView: View {
+    /// 마지막으로 카메라 이동이 완료된 지도 중심 좌표입니다.
     @State private var cameraCenter = MapCameraCenter.seoulCityHall
 
+    /// 네이버 지도 키 설정 여부에 따라 지도 또는 설정 안내 화면을 표시합니다.
     var body: some View {
         Group {
             if MapFeatureDemoConfiguration.naverMapClientID == nil {
@@ -27,6 +30,7 @@ struct NaverMapDemoRootView: View {
         }
     }
 
+    /// Coordinator에서 전달받은 카메라 중심 좌표를 표시하는 읽기 전용 오버레이입니다.
     private var cameraCenterOverlay: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("카메라 중심")
@@ -46,13 +50,17 @@ struct NaverMapDemoRootView: View {
     }
 }
 
+/// `NMFNaverMapView`의 카메라 이벤트를 SwiftUI 상태로 연결하는 UIKit 래퍼입니다.
 private struct NaverMapDemoView: UIViewRepresentable {
+    /// 카메라 이동이 완료된 뒤 새 중심 좌표를 상위 SwiftUI 화면으로 전달합니다.
     let onCameraCenterChanged: (MapCameraCenter) -> Void
 
+    /// 네이버 지도 delegate 이벤트를 처리할 Coordinator를 생성합니다.
     func makeCoordinator() -> Coordinator {
         Coordinator(onCameraCenterChanged: onCameraCenterChanged)
     }
 
+    /// 네이버 지도 UIKit 뷰를 생성하고 고정 옵션과 카메라 delegate를 최초 설정합니다.
     func makeUIView(context: Context) -> NMFNaverMapView {
         let naverMapView = NMFNaverMapView(frame: .zero)
         let mapView = naverMapView.mapView
@@ -79,21 +87,27 @@ private struct NaverMapDemoView: UIViewRepresentable {
         return naverMapView
     }
 
+    /// SwiftUI가 갱신될 때 Coordinator가 최신 중심 좌표 callback을 사용하도록 동기화합니다.
     func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
         context.coordinator.onCameraCenterChanged = onCameraCenterChanged
     }
 
+    /// Representable이 제거될 때 등록했던 카메라 delegate를 해제합니다.
     static func dismantleUIView(_ uiView: NMFNaverMapView, coordinator: Coordinator) {
         uiView.mapView.removeCameraDelegate(delegate: coordinator)
     }
 
+    /// 네이버 지도 카메라 delegate 이벤트를 SwiftUI callback으로 변환합니다.
     final class Coordinator: NSObject, NMFMapViewCameraDelegate {
+        /// 상위 SwiftUI 화면이 제공한 최신 중심 좌표 수신 callback입니다.
         var onCameraCenterChanged: (MapCameraCenter) -> Void
 
+        /// 중심 좌표 callback을 보관하는 Coordinator를 초기화합니다.
         init(onCameraCenterChanged: @escaping (MapCameraCenter) -> Void) {
             self.onCameraCenterChanged = onCameraCenterChanged
         }
 
+        /// 카메라의 연속 이동과 애니메이션이 끝났을 때 최종 중심 좌표를 전달합니다.
         func mapViewCameraIdle(_ mapView: NMFMapView) {
             let target = mapView.cameraPosition.target
             let center = MapCameraCenter(latitude: target.lat, longitude: target.lng)
@@ -105,10 +119,15 @@ private struct NaverMapDemoView: UIViewRepresentable {
     }
 }
 
+/// 네이버 지도 중심 좌표를 SwiftUI에서 비교하고 표시하기 위한 값 타입입니다.
 private struct MapCameraCenter: Equatable {
+    /// 중심점의 위도입니다.
     let latitude: Double
+
+    /// 중심점의 경도입니다.
     let longitude: Double
 
+    /// 데모 지도가 처음 표시할 서울시청 좌표입니다.
     static let seoulCityHall = MapCameraCenter(
         latitude: 37.5665,
         longitude: 126.9780

--- a/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
+++ b/Projects/Features/MapFeature/Demo/Sources/NaverMapDemoView.swift
@@ -207,9 +207,16 @@ private struct NaverMapDemoView: UIViewRepresentable {
         /// 위치 권한 및 위치 조회 실패를 상위 SwiftUI 화면에 알리는 callback입니다.
         var onLocationError: (String) -> Void
 
+        /// 위치 권한을 요청하고 한 번의 현재 위치를 수신하는 Core Location 관리자입니다.
         private let locationManager = CLLocationManager()
+
+        /// `updateUIView`의 반복 호출로 같은 위치 요청이 중복 실행되지 않도록 보관하는 식별자입니다.
         private var handledLocationRequestID: UUID?
+
+        /// 권한 응답 또는 위치 수신을 기다리는 현재 위치 요청이 있는지 나타냅니다.
         private var isLocationRequestPending = false
+
+        /// 위치를 수신한 뒤 카메라를 이동할 지도입니다. Representable 수명주기를 넘겨 보관하지 않도록 약한 참조를 사용합니다.
         private weak var mapView: NMFMapView?
 
         /// 초기화 메서드 - 카메라 중심과 위치 오류 callback을 보관하고 위치 관리자 delegate를 연결합니다.

--- a/Projects/Features/MapFeature/Project.swift
+++ b/Projects/Features/MapFeature/Project.swift
@@ -29,6 +29,7 @@ let project = Project(
             infoPlist: .extendingDefault(
                 with: [
                     "NMFClientID": "$(NMFClientID)",
+                    "NSLocationWhenInUseUsageDescription": "현재 위치를 중심으로 지도를 이동하기 위해 위치 정보가 필요합니다.",
                     "UILaunchScreen": [
                         "UIColorName": "",
                         "UIImageName": "",

--- a/Projects/Features/MapFeature/Project.swift
+++ b/Projects/Features/MapFeature/Project.swift
@@ -24,10 +24,11 @@ let project = Project(
             name: "MapFeatureDemo",
             destinations: [.iPhone],
             product: .app,
-            bundleId: "com.poppang.demo.map",
+            bundleId: "kr.co.poppang.PopPang",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .extendingDefault(
                 with: [
+                    "NMFClientID": "$(NMFClientID)",
                     "UILaunchScreen": [
                         "UIColorName": "",
                         "UIImageName": "",
@@ -39,7 +40,19 @@ let project = Project(
                 .target(name: "MapFeature"),
                 .project(target: "Domain", path: "../../Domain"),
                 .project(target: "Data", path: "../../Data"),
-            ]
+            ],
+            settings: .settings(
+                configurations: [
+                    .debug(
+                        name: "Debug",
+                        xcconfig: .relativeToManifest("../../App/Secrets.xcconfig")
+                    ),
+                    .release(
+                        name: "Release",
+                        xcconfig: .relativeToManifest("../../App/Secrets.xcconfig")
+                    ),
+                ]
+            )
         ),
     ]
 )


### PR DESCRIPTION
## 💡 PR 유형

- [x] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [x] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- `MapFeatureDemo`의 기존 TCA·팝업 목업 화면을 순수 네이버 지도 연구 화면으로 교체했습니다.
- `NMFNaverMapView`를 `UIViewRepresentable`로 감싸 서울시청을 중심으로 전체 화면에 표시했습니다.
- `Projects/App/Secrets.xcconfig`의 `NMFClientID`를 데모 `Info.plist`에 주입하고 앱 시작 시 `NMFAuthManager`에 설정했습니다.
- 네이버 지도 키가 비어 있거나 빌드 설정 치환에 실패한 경우 설정 경로를 안내하도록 처리했습니다.
- Naver Cloud Platform에 등록된 기존 앱 식별자로 지도 인증이 가능하도록 데모 번들 ID를 본 앱과 맞췄습니다.
- 데모가 사용하는 비밀 설정 파일 경로와 용도를 `.gitignore`에 명시했습니다.

## 🚨 관련 이슈

- close #93

## 🎨 스크린샷

|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

### 검증한 내용

- `tuist generate run MapFeatureDemo --no-open`으로 타깃 그래프 생성을 확인했습니다.
- iOS 26.0 iPhone 16 Pro Max 시뮬레이터에서 `MapFeature` scheme Debug 빌드를 확인했습니다.
- 빌드 앱을 시뮬레이터에 설치해 서울시청 중심의 네이버 지도 타일이 표시되는 것을 확인했습니다.

### 설정

- 실제 `NMFClientID` 값은 커밋과 PR 본문에 포함하지 않았습니다.
- 데모는 기존 네이버 콘솔 앱 등록을 재사용하기 위해 `kr.co.poppang.PopPang` 번들 ID를 사용합니다. 같은 시뮬레이터나 기기에 본 앱과 동시에 설치할 수 없습니다.
- UI 변경 스크린샷은 별도 첨부가 필요합니다.
- 빌드 시 NMapsMap SDK 내부 `UIScreen.main`의 iOS 26 deprecation 경고가 발생하지만 이번 변경 코드의 경고는 아닙니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 네이버 지도 기반 데모 화면을 추가했습니다.
  - 지도 중심 좌표를 표시하고 현재 위치로 이동할 수 있습니다.
  - 위치 권한 거부 및 위치 조회 실패 시 안내와 설정 이동을 제공합니다.
  - 지도 인증 키가 없을 경우 설정 방법을 안내합니다.

- **개선 사항**
  - 지도 카메라 변경 사항이 화면에 반영됩니다.
  - 지도 및 위치 기능의 초기화와 오류 처리를 안정화했습니다.

- **기타**
  - 지도 인증 정보와 위치 권한 안내 설정을 추가했습니다.
  - 로컬 비밀 설정 파일이 실수로 포함되지 않도록 관리 규칙을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->